### PR TITLE
refactor(events): update EventEnvelope and MatchmakingEvent schemas to align with CloudEvents 1.0 specification

### DIFF
--- a/pkg/infra/events/schemas/matchmaking_events.pb.go
+++ b/pkg/infra/events/schemas/matchmaking_events.pb.go
@@ -22,20 +22,22 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// EventEnvelope is the common wrapper for all matchmaking events.
+// EventEnvelope follows CloudEvents 1.0 spec (https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md).
 // Ensures replay-api and match-making-api agree on payload structure.
 type EventEnvelope struct {
-	state           protoimpl.MessageState `protogen:"open.v1"`
-	EventId         string                 `protobuf:"bytes,1,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
-	EventType       string                 `protobuf:"bytes,2,opt,name=event_type,json=eventType,proto3" json:"event_type,omitempty"`
-	AggregateId     string                 `protobuf:"bytes,3,opt,name=aggregate_id,json=aggregateId,proto3" json:"aggregate_id,omitempty"`
-	Timestamp       *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
-	Version         int32                  `protobuf:"varint,5,opt,name=version,proto3" json:"version,omitempty"`                                         // Schema version for evolution; consumers can handle multiple versions.
-	Source          string                 `protobuf:"bytes,6,opt,name=source,proto3" json:"source,omitempty"`                                            // Service that produced the event (e.g. "replay-api", "match-making-api").
-	ResourceOwnerId string                 `protobuf:"bytes,7,opt,name=resource_owner_id,json=resourceOwnerId,proto3" json:"resource_owner_id,omitempty"` // RID or owner identifier for multi-tenancy/authorization.
-	CorrelationId   string                 `protobuf:"bytes,8,opt,name=correlation_id,json=correlationId,proto3" json:"correlation_id,omitempty"`         // Optional: for distributed tracing.
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	state       protoimpl.MessageState `protogen:"open.v1"`
+	Id          string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`                   // CloudEvents: id (required) - uniquely identifies the event
+	Type        string                 `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`               // CloudEvents: type (required) - e.g. "PlayerQueued", "MatchCompleted"
+	Source      string                 `protobuf:"bytes,3,opt,name=source,proto3" json:"source,omitempty"`           // CloudEvents: source (required) - e.g. "replay-api", "match-making-api"
+	Specversion string                 `protobuf:"bytes,4,opt,name=specversion,proto3" json:"specversion,omitempty"` // CloudEvents: specversion (required) - e.g. "1.0"
+	Time        *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=time,proto3" json:"time,omitempty"`               // CloudEvents: time (optional) - when the event occurred
+	Subject     string                 `protobuf:"bytes,6,opt,name=subject,proto3" json:"subject,omitempty"`         // CloudEvents: subject (optional) - e.g. player_id, match_id
+	// Extension attributes
+	ResourceOwnerId   string `protobuf:"bytes,7,opt,name=resource_owner_id,json=resourceOwnerId,proto3" json:"resource_owner_id,omitempty"`      // RID or owner identifier for multi-tenancy/authorization
+	CorrelationId     string `protobuf:"bytes,8,opt,name=correlation_id,json=correlationId,proto3" json:"correlation_id,omitempty"`              // For distributed tracing
+	DataschemaVersion int32  `protobuf:"varint,9,opt,name=dataschema_version,json=dataschemaVersion,proto3" json:"dataschema_version,omitempty"` // Payload schema version for evolution; consumers can handle multiple versions
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *EventEnvelope) Reset() {
@@ -68,44 +70,44 @@ func (*EventEnvelope) Descriptor() ([]byte, []int) {
 	return file_pkg_infra_events_schemas_matchmaking_events_proto_rawDescGZIP(), []int{0}
 }
 
-func (x *EventEnvelope) GetEventId() string {
+func (x *EventEnvelope) GetId() string {
 	if x != nil {
-		return x.EventId
+		return x.Id
 	}
 	return ""
 }
 
-func (x *EventEnvelope) GetEventType() string {
+func (x *EventEnvelope) GetType() string {
 	if x != nil {
-		return x.EventType
+		return x.Type
 	}
 	return ""
-}
-
-func (x *EventEnvelope) GetAggregateId() string {
-	if x != nil {
-		return x.AggregateId
-	}
-	return ""
-}
-
-func (x *EventEnvelope) GetTimestamp() *timestamppb.Timestamp {
-	if x != nil {
-		return x.Timestamp
-	}
-	return nil
-}
-
-func (x *EventEnvelope) GetVersion() int32 {
-	if x != nil {
-		return x.Version
-	}
-	return 0
 }
 
 func (x *EventEnvelope) GetSource() string {
 	if x != nil {
 		return x.Source
+	}
+	return ""
+}
+
+func (x *EventEnvelope) GetSpecversion() string {
+	if x != nil {
+		return x.Specversion
+	}
+	return ""
+}
+
+func (x *EventEnvelope) GetTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.Time
+	}
+	return nil
+}
+
+func (x *EventEnvelope) GetSubject() string {
+	if x != nil {
+		return x.Subject
 	}
 	return ""
 }
@@ -124,17 +126,24 @@ func (x *EventEnvelope) GetCorrelationId() string {
 	return ""
 }
 
-// MatchmakingEvent is the top-level message for Kafka. Combines envelope + typed payload.
+func (x *EventEnvelope) GetDataschemaVersion() int32 {
+	if x != nil {
+		return x.DataschemaVersion
+	}
+	return 0
+}
+
+// MatchmakingEvent is the top-level message for Kafka. Combines envelope + typed data (CloudEvents: data).
 type MatchmakingEvent struct {
 	state    protoimpl.MessageState `protogen:"open.v1"`
 	Envelope *EventEnvelope         `protobuf:"bytes,1,opt,name=envelope,proto3" json:"envelope,omitempty"`
-	// Types that are valid to be assigned to Payload:
+	// Types that are valid to be assigned to Data:
 	//
 	//	*MatchmakingEvent_PlayerQueued
 	//	*MatchmakingEvent_MatchCreated
 	//	*MatchmakingEvent_MatchCompleted
 	//	*MatchmakingEvent_RatingsUpdated
-	Payload       isMatchmakingEvent_Payload `protobuf_oneof:"payload"`
+	Data          isMatchmakingEvent_Data `protobuf_oneof:"data"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -176,16 +185,16 @@ func (x *MatchmakingEvent) GetEnvelope() *EventEnvelope {
 	return nil
 }
 
-func (x *MatchmakingEvent) GetPayload() isMatchmakingEvent_Payload {
+func (x *MatchmakingEvent) GetData() isMatchmakingEvent_Data {
 	if x != nil {
-		return x.Payload
+		return x.Data
 	}
 	return nil
 }
 
 func (x *MatchmakingEvent) GetPlayerQueued() *PlayerQueuedPayload {
 	if x != nil {
-		if x, ok := x.Payload.(*MatchmakingEvent_PlayerQueued); ok {
+		if x, ok := x.Data.(*MatchmakingEvent_PlayerQueued); ok {
 			return x.PlayerQueued
 		}
 	}
@@ -194,7 +203,7 @@ func (x *MatchmakingEvent) GetPlayerQueued() *PlayerQueuedPayload {
 
 func (x *MatchmakingEvent) GetMatchCreated() *MatchCreatedPayload {
 	if x != nil {
-		if x, ok := x.Payload.(*MatchmakingEvent_MatchCreated); ok {
+		if x, ok := x.Data.(*MatchmakingEvent_MatchCreated); ok {
 			return x.MatchCreated
 		}
 	}
@@ -203,7 +212,7 @@ func (x *MatchmakingEvent) GetMatchCreated() *MatchCreatedPayload {
 
 func (x *MatchmakingEvent) GetMatchCompleted() *MatchCompletedPayload {
 	if x != nil {
-		if x, ok := x.Payload.(*MatchmakingEvent_MatchCompleted); ok {
+		if x, ok := x.Data.(*MatchmakingEvent_MatchCompleted); ok {
 			return x.MatchCompleted
 		}
 	}
@@ -212,15 +221,15 @@ func (x *MatchmakingEvent) GetMatchCompleted() *MatchCompletedPayload {
 
 func (x *MatchmakingEvent) GetRatingsUpdated() *RatingsUpdatedPayload {
 	if x != nil {
-		if x, ok := x.Payload.(*MatchmakingEvent_RatingsUpdated); ok {
+		if x, ok := x.Data.(*MatchmakingEvent_RatingsUpdated); ok {
 			return x.RatingsUpdated
 		}
 	}
 	return nil
 }
 
-type isMatchmakingEvent_Payload interface {
-	isMatchmakingEvent_Payload()
+type isMatchmakingEvent_Data interface {
+	isMatchmakingEvent_Data()
 }
 
 type MatchmakingEvent_PlayerQueued struct {
@@ -239,13 +248,13 @@ type MatchmakingEvent_RatingsUpdated struct {
 	RatingsUpdated *RatingsUpdatedPayload `protobuf:"bytes,13,opt,name=ratings_updated,json=ratingsUpdated,proto3,oneof"`
 }
 
-func (*MatchmakingEvent_PlayerQueued) isMatchmakingEvent_Payload() {}
+func (*MatchmakingEvent_PlayerQueued) isMatchmakingEvent_Data() {}
 
-func (*MatchmakingEvent_MatchCreated) isMatchmakingEvent_Payload() {}
+func (*MatchmakingEvent_MatchCreated) isMatchmakingEvent_Data() {}
 
-func (*MatchmakingEvent_MatchCompleted) isMatchmakingEvent_Payload() {}
+func (*MatchmakingEvent_MatchCompleted) isMatchmakingEvent_Data() {}
 
-func (*MatchmakingEvent_RatingsUpdated) isMatchmakingEvent_Payload() {}
+func (*MatchmakingEvent_RatingsUpdated) isMatchmakingEvent_Data() {}
 
 type PlayerQueuedPayload struct {
 	state               protoimpl.MessageState `protogen:"open.v1"`
@@ -843,25 +852,25 @@ var File_pkg_infra_events_schemas_matchmaking_events_proto protoreflect.FileDesc
 
 const file_pkg_infra_events_schemas_matchmaking_events_proto_rawDesc = "" +
 	"\n" +
-	"1pkg/infra/events/schemas/matchmaking_events.proto\x12\x15matchmaking.events.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\xab\x02\n" +
-	"\rEventEnvelope\x12\x19\n" +
-	"\bevent_id\x18\x01 \x01(\tR\aeventId\x12\x1d\n" +
-	"\n" +
-	"event_type\x18\x02 \x01(\tR\teventType\x12!\n" +
-	"\faggregate_id\x18\x03 \x01(\tR\vaggregateId\x128\n" +
-	"\ttimestamp\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\x12\x18\n" +
-	"\aversion\x18\x05 \x01(\x05R\aversion\x12\x16\n" +
-	"\x06source\x18\x06 \x01(\tR\x06source\x12*\n" +
+	"1pkg/infra/events/schemas/matchmaking_events.proto\x12\x15matchmaking.events.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\xb9\x02\n" +
+	"\rEventEnvelope\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
+	"\x04type\x18\x02 \x01(\tR\x04type\x12\x16\n" +
+	"\x06source\x18\x03 \x01(\tR\x06source\x12 \n" +
+	"\vspecversion\x18\x04 \x01(\tR\vspecversion\x12.\n" +
+	"\x04time\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\x04time\x12\x18\n" +
+	"\asubject\x18\x06 \x01(\tR\asubject\x12*\n" +
 	"\x11resource_owner_id\x18\a \x01(\tR\x0fresourceOwnerId\x12%\n" +
-	"\x0ecorrelation_id\x18\b \x01(\tR\rcorrelationId\"\xb7\x03\n" +
+	"\x0ecorrelation_id\x18\b \x01(\tR\rcorrelationId\x12-\n" +
+	"\x12dataschema_version\x18\t \x01(\x05R\x11dataschemaVersion\"\xb4\x03\n" +
 	"\x10MatchmakingEvent\x12@\n" +
 	"\benvelope\x18\x01 \x01(\v2$.matchmaking.events.v1.EventEnvelopeR\benvelope\x12Q\n" +
 	"\rplayer_queued\x18\n" +
 	" \x01(\v2*.matchmaking.events.v1.PlayerQueuedPayloadH\x00R\fplayerQueued\x12Q\n" +
 	"\rmatch_created\x18\v \x01(\v2*.matchmaking.events.v1.MatchCreatedPayloadH\x00R\fmatchCreated\x12W\n" +
 	"\x0fmatch_completed\x18\f \x01(\v2,.matchmaking.events.v1.MatchCompletedPayloadH\x00R\x0ematchCompleted\x12W\n" +
-	"\x0fratings_updated\x18\r \x01(\v2,.matchmaking.events.v1.RatingsUpdatedPayloadH\x00R\x0eratingsUpdatedB\t\n" +
-	"\apayload\"\xe8\x02\n" +
+	"\x0fratings_updated\x18\r \x01(\v2,.matchmaking.events.v1.RatingsUpdatedPayloadH\x00R\x0eratingsUpdatedB\x06\n" +
+	"\x04data\"\xe8\x02\n" +
 	"\x13PlayerQueuedPayload\x12\x1b\n" +
 	"\tplayer_id\x18\x01 \x01(\tR\bplayerId\x12\x17\n" +
 	"\agame_id\x18\x02 \x01(\tR\x06gameId\x12\x16\n" +
@@ -944,7 +953,7 @@ var file_pkg_infra_events_schemas_matchmaking_events_proto_goTypes = []any{
 	(*timestamppb.Timestamp)(nil), // 10: google.protobuf.Timestamp
 }
 var file_pkg_infra_events_schemas_matchmaking_events_proto_depIdxs = []int32{
-	10, // 0: matchmaking.events.v1.EventEnvelope.timestamp:type_name -> google.protobuf.Timestamp
+	10, // 0: matchmaking.events.v1.EventEnvelope.time:type_name -> google.protobuf.Timestamp
 	0,  // 1: matchmaking.events.v1.MatchmakingEvent.envelope:type_name -> matchmaking.events.v1.EventEnvelope
 	2,  // 2: matchmaking.events.v1.MatchmakingEvent.player_queued:type_name -> matchmaking.events.v1.PlayerQueuedPayload
 	4,  // 3: matchmaking.events.v1.MatchmakingEvent.match_created:type_name -> matchmaking.events.v1.MatchCreatedPayload

--- a/pkg/infra/events/schemas/matchmaking_events.proto
+++ b/pkg/infra/events/schemas/matchmaking_events.proto
@@ -6,23 +6,25 @@ import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/leet-gaming/match-making-api/pkg/infra/events/schemas;schemas";
 
-// EventEnvelope is the common wrapper for all matchmaking events.
+// EventEnvelope follows CloudEvents 1.0 spec (https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md).
 // Ensures replay-api and match-making-api agree on payload structure.
 message EventEnvelope {
-  string event_id = 1;
-  string event_type = 2;
-  string aggregate_id = 3;
-  google.protobuf.Timestamp timestamp = 4;
-  int32 version = 5;  // Schema version for evolution; consumers can handle multiple versions.
-  string source = 6;  // Service that produced the event (e.g. "replay-api", "match-making-api").
-  string resource_owner_id = 7;  // RID or owner identifier for multi-tenancy/authorization.
-  string correlation_id = 8;  // Optional: for distributed tracing.
+  string id = 1;           // CloudEvents: id (required) - uniquely identifies the event
+  string type = 2;         // CloudEvents: type (required) - e.g. "PlayerQueued", "MatchCompleted"
+  string source = 3;        // CloudEvents: source (required) - e.g. "replay-api", "match-making-api"
+  string specversion = 4;   // CloudEvents: specversion (required) - e.g. "1.0"
+  google.protobuf.Timestamp time = 5;  // CloudEvents: time (optional) - when the event occurred
+  string subject = 6;      // CloudEvents: subject (optional) - e.g. player_id, match_id
+  // Extension attributes
+  string resource_owner_id = 7;  // RID or owner identifier for multi-tenancy/authorization
+  string correlation_id = 8;    // For distributed tracing
+  int32 dataschema_version = 9; // Payload schema version for evolution; consumers can handle multiple versions
 }
 
-// MatchmakingEvent is the top-level message for Kafka. Combines envelope + typed payload.
+// MatchmakingEvent is the top-level message for Kafka. Combines envelope + typed data (CloudEvents: data).
 message MatchmakingEvent {
   EventEnvelope envelope = 1;
-  oneof payload {
+  oneof data {
     PlayerQueuedPayload player_queued = 10;
     MatchCreatedPayload match_created = 11;
     MatchCompletedPayload match_completed = 12;


### PR DESCRIPTION
## Summary

This PR updates the matchmaking event schemas to align with **CloudEvents 1.0** and supports the Kafka producer implementation (2501-003) in replay-api. It renames envelope fields to CloudEvents terminology (`id`, `type`, `source`, `specversion`, `time`, `subject`, `data`) and adds documentation for the partition key strategy.

## Key Features Added

### Event Schemas (CloudEvents Alignment)

- **EventEnvelope**: Renamed fields to CloudEvents 1.0 (`event_id` → `id`, `event_type` → `type`, `aggregate_id` → `subject`, `timestamp` → `time`)
- **specversion**: New required field for CloudEvents spec version (e.g. `"1.0"`)
- **dataschema_version**: Renamed from `version` for payload schema evolution
- **MatchmakingEvent**: Renamed `payload` → `data` to match CloudEvents
- **Constants**: Added `CloudEventsSpecVersion` constant

### Documentation

- **EVENT_SCHEMAS.md**: Updated to describe CloudEvents fields and structure
- **PARTITION_KEY_STRATEGY.md** (replay-api): Documents partition keys for PlayerQueued (`game_id`+`region`) and MatchCompleted (`match_id`)

### Supporting replay-api Producer Implementation

- **PlayerQueued producer**: Publishes to `matchmaking.commands` with resource ownership validation and retry logic
- **MatchCompleted producer**: Publishes to `matchmaking.matches` with same validation and retry
- **Configuration**: Topics, retries, backoff, and enable/disable via environment variables

## Architecture Highlights

**Design Patterns:**
- CloudEvents 1.0 for event structure
- Extension attributes for `resource_owner_id`, `correlation_id`, `dataschema_version`

**Key Components:**
- `EventEnvelope`: CloudEvents-compliant context attributes
- `MatchmakingEvent`: Envelope + typed `data` (oneof payloads)
- `MatchmakingProducer` (replay-api): Publishes with partition key strategy and validation

**Security & Best Practices:**
- Resource ownership validation before produce (`tenant_id`, `client_id`, `resource_owner_id`)
- Retries with exponential backoff for transient failures
- Producer can be disabled via config for non-prod

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update

> **Note:** Schema field renames are breaking for consumers that rely on the old JSON field names. Consumers must be updated to use the new CloudEvents field names.

## Related Issue

Closes #17 (2501-003 - Producer Implementation)

## Test Plan

- [x] Build project: `go build ./...`
- [x] Run unit tests: `go test ./...`
- [ ] Run integration tests (if applicable)
- [ ] Manual testing performed
- [ ] All API endpoints tested
- [ ] Error handling verified
- [ ] Edge cases tested
- [ ] Performance tested (if applicable)
- [ ] Security checks performed
- [ ] No sensitive data in commits

### Test Steps

1. Run `make proto-gen` to regenerate Go code from protos
2. Build: `go build ./...`
3. Run tests: `go test ./...`
4. (replay-api) Run producer unit tests: `go test ./pkg/infra/kafka/...`

## Files Changed

- match-making-api: `matchmaking_events.proto`, `matchmaking_events.pb.go`, `constants.go`, `.docs/EVENT_SCHEMAS.md`
- replay-api: `matchmaking_producer.go`, `matchmaking_producer_config.go`, `matchmaking_producer_test.go`, schemas, docs, Kafka topics

## Database Migration

N/A

## Dependencies

- [x] No new dependencies added (match-making-api)
- [ ] New dependencies added (replay-api: uses existing `segmentio/kafka-go`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] All method names, comments, and documentation are in English
- [ ] OpenAPI specification updated (if API changes were made)
- [x] Logging added for audit purposes (if applicable)

## Additional Notes

- **Breaking change**: Consumers must migrate to the new CloudEvents field names (`id`, `type`, `subject`, `time`, `data` instead of `event_id`, `event_type`, `aggregate_id`, `timestamp`, `payload`)
- replay-api changes are in a separate repository; this PR focuses on schema updates in match-making-api
- Partition key strategy: PlayerQueued → `game_id`+`region`; MatchCompleted → `match_id`