### PR TITLE
feat: add matchmaking worker and Redis integration and queue status update

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,12 @@ KAFKA_BOOTSTRAP=kafka-1:29092,kafka-2:39092
 KAFKA_VERSION=3.6.0
 KAFKA_CONSUMER_GROUP_ID=match-making-group
 KAFKA_PARTITION_ASSIGNMENT_STRATEGY=range
+
+# ============================================
+# Redis / Dragonfly Configuration
+# ============================================
+# Used for distributed ActiveQueueStore (matchmaking queue state)
+# Development: localhost:6379
+# Docker: dragonfly:6379
+REDIS_ADDR=localhost:6379
+REDIS_PASSWORD=

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,17 +7,26 @@ COPY . .
 COPY .env .env
 
 RUN CGO_ENABLED=0 go build -v -o match-making-api-http-service ./cmd/rest-api/main.go
+RUN CGO_ENABLED=0 go build -v -o matchmaking-worker ./cmd/workers/matchmaking/main.go
 RUN mkdir -p /app/match_making_files
 RUN mkdir -p /app/coverage
 
-# runtime
+# runtime — REST API (default)
 FROM scratch AS runtime
 COPY --from=build /app/match-making-api-http-service ./app/
 COPY --from=build /app/coverage ./app/coverage
 COPY --from=build /app/.env ./.env
 
-# Set environment variable to increase stack size
 ENV GODEBUG=stackguard=99999000000000
 
 EXPOSE 4991
 CMD ["./app/match-making-api-http-service"]
+
+# runtime — Matchmaking Worker (consumer + ticker)
+FROM scratch AS matchmaking-worker
+COPY --from=build /app/matchmaking-worker ./app/
+COPY --from=build /app/.env ./.env
+
+ENV GODEBUG=stackguard=99999000000000
+
+CMD ["./app/matchmaking-worker"]

--- a/Makefile
+++ b/Makefile
@@ -10,27 +10,43 @@ else
 	DETECTED_OS := $(shell uname -s)
 endif
 
-# Define the output binary name based on the OS
+# Define the output binary names based on the OS
 ifeq ($(DETECTED_OS),Windows)
-	BINARY_NAME := match-making-api-http-service.exe
+	BINARY_REST_API := match-making-api-http-service.exe
+	BINARY_MATCHMAKING_WORKER := matchmaking-worker.exe
 else
-	BINARY_NAME := match-making-api-http-service
+	BINARY_REST_API := match-making-api-http-service
+	BINARY_MATCHMAKING_WORKER := matchmaking-worker
 endif
 
 build-rest-api:
-	@echo "Building API for $(DETECTED_OS)"
+	@echo "Building REST API for $(DETECTED_OS)"
 ifeq ($(DETECTED_OS),Windows)
-	@echo "Building for Windows"
-	@go build -o $(BINARY_NAME) ./cmd/rest-api/main.go
+	@go build -o $(BINARY_REST_API) ./cmd/rest-api/main.go
 else
-	@echo "Building for Unix-like system"
-	CGO_ENABLED=0 go build -o $(BINARY_NAME) ./cmd/rest-api/main.go
+	CGO_ENABLED=0 go build -o $(BINARY_REST_API) ./cmd/rest-api/main.go
 endif
 
+build-matchmaking-worker:
+	@echo "Building Matchmaking Worker for $(DETECTED_OS)"
+ifeq ($(DETECTED_OS),Windows)
+	@go build -o $(BINARY_MATCHMAKING_WORKER) ./cmd/workers/matchmaking/main.go
+else
+	CGO_ENABLED=0 go build -o $(BINARY_MATCHMAKING_WORKER) ./cmd/workers/matchmaking/main.go
+endif
+
+build-all: build-rest-api build-matchmaking-worker
+	@echo "All binaries built successfully"
+
 start-rest-api:
-	@echo "Running API"
+	@echo "Running REST API"
 	@export DEV_ENV="true"
-	@./$(BINARY_NAME)
+	@./$(BINARY_REST_API)
+
+start-matchmaking-worker:
+	@echo "Running Matchmaking Worker"
+	@export DEV_ENV="true"
+	@./$(BINARY_MATCHMAKING_WORKER)
 
 test-docker:
 	@echo "Running tests"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,56 @@
-Tenacity Scheme:
+## Architecture
+
+### Services
+
+This repository produces **two** independent binaries:
+
+| Binary | Path | Description |
+|---|---|---|
+| `match-making-api` | `cmd/rest-api/` | HTTP REST API (port 4991) |
+| `matchmaking-worker` | `cmd/workers/matchmaking/` | Kafka consumer + periodic ticker (no HTTP) |
+
+The **REST API** handles HTTP requests (games, lobbies, invitations, etc.).
+
+The **Matchmaking Worker** runs background processes:
+- **PlayerQueuedConsumer** — consumes `PlayerQueued` events from `matchmaking.commands` topic and adds players to the matchmaking pool.
+- **QueueStatusTicker** — every 5s, reads active queue entries from Dragonfly, refreshes positions from pool state, and publishes `QueueStatusUpdated` events to `websocket.broadcasts`.
+
+Both share the same codebase (`pkg/`) but use different DI injection:
+- API: `infra.Inject` + `domain.Inject` (full stack: MongoDB, Kafka, Redis, IAM, billing, etc.)
+- Worker: `infra.InjectWorker` + `domain.InjectWorker` (slim: MongoDB, Kafka, Redis, game, pairing, schedules)
+
+### Infrastructure
+
+| Service | Purpose | Default Port |
+|---|---|---|
+| MongoDB | Persistent storage (games, regions, pools) | 37019 |
+| Kafka | Event streaming (commands, events, broadcasts) | 29092 |
+| Dragonfly | Distributed queue state (`ActiveQueueStore`) | 6379 |
+
+### Quick Start
+
+```bash
+# Start all services (API + worker + infra)
+docker-compose -f docker-compose.dev.yml up -d
+
+# Or build locally
+make build-all
+make start-rest-api          # terminal 1
+make start-matchmaking-worker # terminal 2
+```
+
+### Environment Variables
+
+See `.env.example` for all available settings. Key additions:
+
+```env
+REDIS_ADDR=localhost:6379    # Dragonfly/Redis address
+REDIS_PASSWORD=              # Optional auth
+```
+
+---
+
+Tenancy Scheme:
 ```mermaid
 graph TD
     Tenant[Tenant]

--- a/cmd/rest-api/main.go
+++ b/cmd/rest-api/main.go
@@ -11,7 +11,6 @@ import (
 	"github.com/leet-gaming/match-making-api/pkg/domain"
 	"github.com/leet-gaming/match-making-api/pkg/infra"
 	"github.com/leet-gaming/match-making-api/pkg/infra/ioc"
-	"github.com/leet-gaming/match-making-api/pkg/infra/kafka"
 )
 
 func main() {
@@ -26,22 +25,6 @@ func main() {
 	c := builder.WithEnvFile().With(infra.Inject).With(domain.Inject).Build()
 
 	defer builder.Close(c)
-
-	// Start Kafka consumer for matchmaking commands (PlayerQueued from replay-api)
-	var playerQueuedConsumer *kafka.PlayerQueuedConsumer
-	if err := c.Resolve(&playerQueuedConsumer); err != nil {
-		slog.Warn("PlayerQueuedConsumer not available, skipping consumer startup", "err", err)
-	} else {
-		consumerCtx, consumerCancel := context.WithCancel(ctx)
-		defer consumerCancel()
-
-		go func() {
-			slog.Info("Starting PlayerQueuedConsumer for matchmaking.commands topic")
-			if err := playerQueuedConsumer.Start(consumerCtx); err != nil {
-				slog.Error("PlayerQueuedConsumer stopped with error", "error", err)
-			}
-		}()
-	}
 
 	router := routing.NewRouter(ctx, c)
 

--- a/cmd/workers/matchmaking/main.go
+++ b/cmd/workers/matchmaking/main.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/leet-gaming/match-making-api/pkg/domain"
+	"github.com/leet-gaming/match-making-api/pkg/domain/pairing/usecases"
+	"github.com/leet-gaming/match-making-api/pkg/infra"
+	"github.com/leet-gaming/match-making-api/pkg/infra/ioc"
+	"github.com/leet-gaming/match-making-api/pkg/infra/kafka"
+)
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	slog.SetDefault(logger)
+
+	// Slim inject — only Kafka, Redis, MongoDB (regions/games), and pairing domain.
+	// Skips IAM, billing, squad, lobbies which are REST API-only concerns.
+	builder := ioc.NewContainerBuilder()
+	c := builder.WithEnvFile().With(infra.InjectWorker).With(domain.InjectWorker).Build()
+	defer builder.Close(c)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Graceful shutdown on SIGINT/SIGTERM
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		sig := <-sigCh
+		slog.Info("Received shutdown signal, stopping worker...", "signal", sig)
+		cancel()
+	}()
+
+	// Start PlayerQueuedConsumer
+	var consumer *kafka.PlayerQueuedConsumer
+	if err := c.Resolve(&consumer); err != nil {
+		slog.Error("Failed to resolve PlayerQueuedConsumer", "error", err)
+		os.Exit(1)
+	}
+
+	go func() {
+		slog.Info("Starting PlayerQueuedConsumer for matchmaking.commands topic")
+		if err := consumer.Start(ctx); err != nil {
+			slog.Error("PlayerQueuedConsumer stopped with error", "error", err)
+		}
+	}()
+
+	// Start QueueStatusTicker
+	var ticker *usecases.QueueStatusTicker
+	if err := c.Resolve(&ticker); err != nil {
+		slog.Error("Failed to resolve QueueStatusTicker", "error", err)
+		os.Exit(1)
+	}
+
+	slog.Info("Starting QueueStatusTicker for periodic queue position updates")
+	if err := ticker.Start(ctx); err != nil {
+		slog.Error("QueueStatusTicker stopped with error", "error", err)
+		os.Exit(1)
+	}
+
+	slog.Info("Matchmaking worker shut down gracefully")
+}

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -4,20 +4,45 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      target: runtime
     ports:
       - "4991:4991"
     volumes:
       - .blob:/app/match_making_files
     depends_on:
       - mongodb
+      - kafka
+      - dragonfly
     env_file:
       - .env
     environment:
       - DEV_ENV="docker"
       - MONGO_URI=mongodb://mongodb:37019/match-making
       - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+      - REDIS_ADDR=dragonfly:6379
     networks:
       - svc
+
+  matchmaking-worker:
+    container_name: "matchmaking-worker"
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: matchmaking-worker
+    depends_on:
+      - mongodb
+      - kafka
+      - dragonfly
+    env_file:
+      - .env
+    environment:
+      - DEV_ENV="docker"
+      - MONGO_URI=mongodb://mongodb:37019/match-making
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+      - REDIS_ADDR=dragonfly:6379
+    networks:
+      - svc
+    restart: unless-stopped
 
   mongodb:
     container_name: "mongodb"
@@ -28,6 +53,16 @@ services:
       - .mongodb:/data/db
     networks:
       - default
+      - svc
+
+  dragonfly:
+    container_name: "dragonfly"
+    image: docker.dragonflydb.io/dragonflydb/dragonfly:latest
+    ports:
+      - "6379:6379"
+    volumes:
+      - .dragonfly:/data
+    networks:
       - svc
 
   zookeeper:

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,9 @@ require (
 
 require (
 	github.com/KyleBanks/depth v1.2.1 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/spec v0.21.0 // indirect
@@ -32,6 +34,7 @@ require (
 	github.com/montanaflynn/stats v0.7.1 // indirect
 	github.com/pierrec/lz4/v4 v4.1.15 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/redis/go-redis/v9 v9.18.0 // indirect
 	github.com/resource-ownership/go-common v0.0.0-20260105131913-f0c9a53e9a6d // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
@@ -41,6 +44,7 @@ require (
 	github.com/xdg-go/scram v1.1.2 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/sync v0.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,11 @@
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
@@ -46,6 +50,8 @@ github.com/pierrec/lz4/v4 v4.1.15 h1:MO0/ucJhngq7299dKLwIMtgTfbkoSPF6AoMYDd8Q4q0
 github.com/pierrec/lz4/v4 v4.1.15/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
+github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
 github.com/replay-api/replay-common v0.0.0-20260105132037-5c54623d9838 h1:FSY5lx7lMhPtS+5eTfXbvqio4/xa8P1Xn1Bk541QcZM=
 github.com/replay-api/replay-common v0.0.0-20260105132037-5c54623d9838/go.mod h1:YUuQSHWT5f2V2sx4zkrt/3S8iyUWmiL6kCZJ4YSdjdc=
 github.com/resource-ownership/go-common v0.0.0-20260105131913-f0c9a53e9a6d h1:1SI2zL7HX/QbXsxy4CcdQiSOAkaBgIGWtkg2WUnSqZg=
@@ -87,6 +93,8 @@ go.opentelemetry.io/otel/sdk/metric v1.34.0 h1:5CeK9ujjbFVL5c1PhLuStg1wxA7vQv7ce
 go.opentelemetry.io/otel/sdk/metric v1.34.0/go.mod h1:jQ/r8Ze28zRKoNRdkjCZxfs6YvBTG1+YIqyFVFYec5w=
 go.opentelemetry.io/otel/trace v1.34.0 h1:+ouXS2V8Rd4hp4580a8q23bg0azF2nI8cqLYnC8mh/k=
 go.opentelemetry.io/otel/trace v1.34.0/go.mod h1:Svm7lSjQD7kG7KJ/MUHPVXSDGz2OX4h0M2jHBhmSfRE=
+go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
+go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/mock v0.5.2 h1:LbtPTcP8A5k9WPXj54PPPbjcI4Y6lhyOZXn+VS7wNko=
 go.uber.org/mock v0.5.2/go.mod h1:wLlUxC2vVTPTaE3UD51E0BGOAElKrILxhVSDYQLld5o=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/pkg/domain/pairing/container.go
+++ b/pkg/domain/pairing/container.go
@@ -11,7 +11,9 @@ import (
 	"github.com/leet-gaming/match-making-api/pkg/domain/pairing/usecases"
 	pairing_value_objects "github.com/leet-gaming/match-making-api/pkg/domain/pairing/value-objects"
 	schedules_in_ports "github.com/leet-gaming/match-making-api/pkg/domain/schedules/ports/in"
+	"github.com/leet-gaming/match-making-api/pkg/infra/cache"
 	"github.com/leet-gaming/match-making-api/pkg/infra/kafka"
+	"github.com/redis/go-redis/v9"
 )
 
 // mockPoolReader is a simple in-memory implementation for development
@@ -88,6 +90,13 @@ func Inject(c container.Container) error {
 		return err
 	}
 
+	// Register ActiveQueueStore — backed by Redis/Dragonfly for distributed access (#22)
+	if err := c.Singleton(func(redisClient *redis.Client) pairing_out.ActiveQueueStore {
+		return cache.NewRedisActiveQueueStore(redisClient)
+	}); err != nil {
+		return err
+	}
+
 	// Register MatchmakingEventConsumer
 	if err := c.Singleton(func(
 		addAndFindNextPair *usecases.AddAndFindNextPairUseCase,
@@ -95,8 +104,9 @@ func Inject(c container.Container) error {
 		regionReader game_out.RegionReader,
 		poolReader pairing_out.PoolReader,
 		poolWriter pairing_out.PoolWriter,
+		aqStore pairing_out.ActiveQueueStore,
 	) *usecases.MatchmakingEventConsumer {
-		return usecases.NewMatchmakingEventConsumer(addAndFindNextPair, eventPublisher, regionReader, poolReader, poolWriter)
+		return usecases.NewMatchmakingEventConsumer(addAndFindNextPair, eventPublisher, regionReader, poolReader, poolWriter, aqStore)
 	}); err != nil {
 		return err
 	}
@@ -109,6 +119,19 @@ func Inject(c container.Container) error {
 	) *kafka.PlayerQueuedConsumer {
 		groupID := "match-making-api-commands"
 		return kafka.NewPlayerQueuedConsumer(client, groupID, eventConsumer.HandlePlayerQueuedProto)
+	}); err != nil {
+		return err
+	}
+
+	// Register QueueStatusTicker — periodic broadcaster of queue position updates (#22)
+	if err := c.Singleton(func(
+		aqStore pairing_out.ActiveQueueStore,
+		poolReader pairing_out.PoolReader,
+		regionReader game_out.RegionReader,
+		eventPublisher *kafka.EventPublisher,
+	) *usecases.QueueStatusTicker {
+		cfg := usecases.DefaultQueueStatusTickerConfig()
+		return usecases.NewQueueStatusTicker(aqStore, poolReader, regionReader, eventPublisher, cfg)
 	}); err != nil {
 		return err
 	}

--- a/pkg/domain/pairing/entities/active_queue.go
+++ b/pkg/domain/pairing/entities/active_queue.go
@@ -1,0 +1,92 @@
+package entities
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ActiveQueueEntry represents a player actively waiting in the matchmaking queue.
+// It stores metadata needed for periodic position updates and WebSocket delivery.
+type ActiveQueueEntry struct {
+	PlayerID        uuid.UUID `json:"player_id"`
+	GameID          uuid.UUID `json:"game_id"`
+	RegionSlug      string    `json:"region"`
+	TenantID        string    `json:"tenant_id"`
+	ClientID        string    `json:"client_id"`
+	ResourceOwnerID string    `json:"resource_owner_id"`
+	Position        int       `json:"position"`
+	JoinedAt        time.Time `json:"joined_at"`
+}
+
+// InMemoryActiveQueueStore is a thread-safe in-memory implementation of
+// pairing_out.ActiveQueueStore. Useful for testing and development.
+//
+// For production use, prefer RedisActiveQueueStore which supports distributed access.
+type InMemoryActiveQueueStore struct {
+	mu      sync.RWMutex
+	entries map[uuid.UUID]*ActiveQueueEntry
+}
+
+// NewInMemoryActiveQueueStore creates a new empty in-memory store.
+func NewInMemoryActiveQueueStore() *InMemoryActiveQueueStore {
+	return &InMemoryActiveQueueStore{
+		entries: make(map[uuid.UUID]*ActiveQueueEntry),
+	}
+}
+
+func (s *InMemoryActiveQueueStore) Register(_ context.Context, entry *ActiveQueueEntry) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if existing, ok := s.entries[entry.PlayerID]; ok {
+		entry.JoinedAt = existing.JoinedAt
+	}
+
+	s.entries[entry.PlayerID] = entry
+	return nil
+}
+
+func (s *InMemoryActiveQueueStore) Remove(_ context.Context, playerID uuid.UUID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.entries, playerID)
+	return nil
+}
+
+func (s *InMemoryActiveQueueStore) Get(_ context.Context, playerID uuid.UUID) (*ActiveQueueEntry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.entries[playerID], nil
+}
+
+func (s *InMemoryActiveQueueStore) GetAll(_ context.Context) ([]*ActiveQueueEntry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	result := make([]*ActiveQueueEntry, 0, len(s.entries))
+	for _, e := range s.entries {
+		cp := *e
+		result = append(result, &cp)
+	}
+	return result, nil
+}
+
+func (s *InMemoryActiveQueueStore) Count(_ context.Context) (int, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.entries), nil
+}
+
+func (s *InMemoryActiveQueueStore) UpdatePosition(_ context.Context, playerID uuid.UUID, position int) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if entry, ok := s.entries[playerID]; ok {
+		entry.Position = position
+		return true, nil
+	}
+	return false, nil
+}

--- a/pkg/domain/pairing/entities/active_queue_test.go
+++ b/pkg/domain/pairing/entities/active_queue_test.go
@@ -1,0 +1,171 @@
+package entities_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/leet-gaming/match-making-api/pkg/domain/pairing/entities"
+)
+
+func TestInMemoryActiveQueueStore_RegisterAndGet(t *testing.T) {
+	ctx := context.Background()
+	store := entities.NewInMemoryActiveQueueStore()
+
+	playerID := uuid.New()
+	entry := &entities.ActiveQueueEntry{
+		PlayerID:        playerID,
+		GameID:          uuid.New(),
+		RegionSlug:      "us-east-1",
+		TenantID:        uuid.New().String(),
+		ClientID:        uuid.New().String(),
+		ResourceOwnerID: uuid.New().String(),
+		Position:        3,
+		JoinedAt:        time.Now().UTC(),
+	}
+
+	require.NoError(t, store.Register(ctx, entry))
+
+	got, err := store.Get(ctx, playerID)
+	require.NoError(t, err)
+	assert.NotNil(t, got)
+	assert.Equal(t, playerID, got.PlayerID)
+	assert.Equal(t, "us-east-1", got.RegionSlug)
+	assert.Equal(t, 3, got.Position)
+}
+
+func TestInMemoryActiveQueueStore_RegisterIdempotent(t *testing.T) {
+	ctx := context.Background()
+	store := entities.NewInMemoryActiveQueueStore()
+
+	playerID := uuid.New()
+	originalTime := time.Now().UTC().Add(-5 * time.Minute)
+
+	require.NoError(t, store.Register(ctx, &entities.ActiveQueueEntry{
+		PlayerID: playerID,
+		Position: 5,
+		JoinedAt: originalTime,
+	}))
+
+	require.NoError(t, store.Register(ctx, &entities.ActiveQueueEntry{
+		PlayerID: playerID,
+		Position: 2,
+		JoinedAt: time.Now().UTC(),
+	}))
+
+	got, err := store.Get(ctx, playerID)
+	require.NoError(t, err)
+	assert.NotNil(t, got)
+	assert.Equal(t, 2, got.Position)
+	assert.Equal(t, originalTime, got.JoinedAt, "JoinedAt should be preserved on re-register")
+}
+
+func TestInMemoryActiveQueueStore_Remove(t *testing.T) {
+	ctx := context.Background()
+	store := entities.NewInMemoryActiveQueueStore()
+
+	playerID := uuid.New()
+	require.NoError(t, store.Register(ctx, &entities.ActiveQueueEntry{
+		PlayerID: playerID,
+		Position: 1,
+		JoinedAt: time.Now().UTC(),
+	}))
+
+	count, _ := store.Count(ctx)
+	assert.Equal(t, 1, count)
+
+	require.NoError(t, store.Remove(ctx, playerID))
+	count, _ = store.Count(ctx)
+	assert.Equal(t, 0, count)
+
+	got, err := store.Get(ctx, playerID)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestInMemoryActiveQueueStore_RemoveNonExistent(t *testing.T) {
+	ctx := context.Background()
+	store := entities.NewInMemoryActiveQueueStore()
+	require.NoError(t, store.Remove(ctx, uuid.New()))
+
+	count, _ := store.Count(ctx)
+	assert.Equal(t, 0, count)
+}
+
+func TestInMemoryActiveQueueStore_GetAll(t *testing.T) {
+	ctx := context.Background()
+	store := entities.NewInMemoryActiveQueueStore()
+
+	ids := []uuid.UUID{uuid.New(), uuid.New(), uuid.New()}
+	for i, id := range ids {
+		require.NoError(t, store.Register(ctx, &entities.ActiveQueueEntry{
+			PlayerID:   id,
+			RegionSlug: "eu-west-1",
+			Position:   i + 1,
+			JoinedAt:   time.Now().UTC(),
+		}))
+	}
+
+	all, err := store.GetAll(ctx)
+	require.NoError(t, err)
+	assert.Len(t, all, 3)
+
+	// Verify returned copies don't share references
+	all[0].Position = 999
+	original, _ := store.Get(ctx, all[0].PlayerID)
+	assert.NotEqual(t, 999, original.Position, "GetAll should return copies")
+}
+
+func TestInMemoryActiveQueueStore_UpdatePosition(t *testing.T) {
+	ctx := context.Background()
+	store := entities.NewInMemoryActiveQueueStore()
+
+	playerID := uuid.New()
+	require.NoError(t, store.Register(ctx, &entities.ActiveQueueEntry{
+		PlayerID: playerID,
+		Position: 10,
+		JoinedAt: time.Now().UTC(),
+	}))
+
+	ok, err := store.UpdatePosition(ctx, playerID, 5)
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	got, _ := store.Get(ctx, playerID)
+	assert.Equal(t, 5, got.Position)
+}
+
+func TestInMemoryActiveQueueStore_UpdatePositionNotFound(t *testing.T) {
+	ctx := context.Background()
+	store := entities.NewInMemoryActiveQueueStore()
+
+	ok, err := store.UpdatePosition(ctx, uuid.New(), 5)
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestInMemoryActiveQueueStore_Count(t *testing.T) {
+	ctx := context.Background()
+	store := entities.NewInMemoryActiveQueueStore()
+
+	count, _ := store.Count(ctx)
+	assert.Equal(t, 0, count)
+
+	require.NoError(t, store.Register(ctx, &entities.ActiveQueueEntry{
+		PlayerID: uuid.New(),
+		JoinedAt: time.Now().UTC(),
+	}))
+	count, _ = store.Count(ctx)
+	assert.Equal(t, 1, count)
+
+	require.NoError(t, store.Register(ctx, &entities.ActiveQueueEntry{
+		PlayerID: uuid.New(),
+		JoinedAt: time.Now().UTC(),
+	}))
+	count, _ = store.Count(ctx)
+	assert.Equal(t, 2, count)
+}

--- a/pkg/domain/pairing/ports/out/active_queue.go
+++ b/pkg/domain/pairing/ports/out/active_queue.go
@@ -1,0 +1,34 @@
+package pairing_out
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/leet-gaming/match-making-api/pkg/domain/pairing/entities"
+)
+
+// ActiveQueueStore defines the contract for tracking players actively waiting
+// in matchmaking queues. Implementations may be in-memory (for testing) or
+// backed by a distributed store like Redis/Dragonfly (for production).
+type ActiveQueueStore interface {
+	// Register adds or updates a player in the active queue.
+	// If the player is already registered, their position is updated
+	// but the original JoinedAt time is preserved.
+	Register(ctx context.Context, entry *entities.ActiveQueueEntry) error
+
+	// Remove removes a player from the active queue (e.g. matched or left).
+	Remove(ctx context.Context, playerID uuid.UUID) error
+
+	// Get returns the entry for a specific player, or nil if not found.
+	Get(ctx context.Context, playerID uuid.UUID) (*entities.ActiveQueueEntry, error)
+
+	// GetAll returns a snapshot of all active queue entries.
+	GetAll(ctx context.Context) ([]*entities.ActiveQueueEntry, error)
+
+	// Count returns the number of players currently in the active queue.
+	Count(ctx context.Context) (int, error)
+
+	// UpdatePosition updates the position for a specific player.
+	// Returns false if the player is not in the store.
+	UpdatePosition(ctx context.Context, playerID uuid.UUID, position int) (bool, error)
+}

--- a/pkg/domain/pairing/usecases/matchmaking_event_consumer.go
+++ b/pkg/domain/pairing/usecases/matchmaking_event_consumer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	game_out "github.com/leet-gaming/match-making-api/pkg/domain/game/ports/out"
@@ -32,6 +33,7 @@ type MatchmakingEventConsumer struct {
 	regionReader       game_out.RegionReader
 	poolReader         pairing_out.PoolReader
 	poolWriter         pairing_out.PoolWriter
+	activeQueueStore   pairing_out.ActiveQueueStore
 }
 
 // NewMatchmakingEventConsumer creates a new consumer for matchmaking events
@@ -41,6 +43,7 @@ func NewMatchmakingEventConsumer(
 	regionReader game_out.RegionReader,
 	poolReader pairing_out.PoolReader,
 	poolWriter pairing_out.PoolWriter,
+	activeQueueStore pairing_out.ActiveQueueStore,
 ) *MatchmakingEventConsumer {
 	return &MatchmakingEventConsumer{
 		addAndFindNextPair: addAndFindNextPair,
@@ -48,6 +51,7 @@ func NewMatchmakingEventConsumer(
 		regionReader:       regionReader,
 		poolReader:         poolReader,
 		poolWriter:         poolWriter,
+		activeQueueStore:   activeQueueStore,
 	}
 }
 
@@ -337,6 +341,16 @@ func (c *MatchmakingEventConsumer) HandlePlayerQueuedProto(ctx context.Context, 
 			"players", pair.Match,
 			"event_id", envelope.GetId())
 
+		// Remove matched players from active queue (#22 — they no longer need position updates)
+		if c.activeQueueStore != nil {
+			for pid := range pair.Match {
+				if err := c.activeQueueStore.Remove(ctx, pid); err != nil {
+					slog.WarnContext(ctx, "Failed to remove matched player from active queue",
+						"player_id", pid, "error", err)
+				}
+			}
+		}
+
 		// Extract player IDs from the pair
 		playerIDs := make([]uuid.UUID, 0, len(pair.Match))
 		for pid := range pair.Match {
@@ -357,6 +371,23 @@ func (c *MatchmakingEventConsumer) HandlePlayerQueuedProto(ctx context.Context, 
 			// Don't return error — the match was created, just the notification failed
 		}
 	} else {
+		// Register player in active queue for periodic position updates (#22)
+		if c.activeQueueStore != nil {
+			if err := c.activeQueueStore.Register(ctx, &pairing_entities.ActiveQueueEntry{
+				PlayerID:        playerID,
+				GameID:          gameID,
+				RegionSlug:      payload.GetRegion(),
+				TenantID:        payload.GetTenantId(),
+				ClientID:        payload.GetClientId(),
+				ResourceOwnerID: envelope.GetResourceOwnerId(),
+				Position:        position,
+				JoinedAt:        time.Now().UTC(),
+			}); err != nil {
+				slog.WarnContext(ctx, "Failed to register player in active queue",
+					"player_id", playerID, "error", err)
+			}
+		}
+
 		slog.InfoContext(ctx, "Player added to pool from PlayerQueued event",
 			"pool_size", len(pool.Parties),
 			"position", position,

--- a/pkg/domain/pairing/usecases/matchmaking_event_consumer_test.go
+++ b/pkg/domain/pairing/usecases/matchmaking_event_consumer_test.go
@@ -59,6 +59,7 @@ func TestMatchmakingEventConsumer_HandleQueueEvent(t *testing.T) {
 			mockRegionReader,
 			mockPoolReader,
 			mockPoolWriter,
+			pairing_entities.NewInMemoryActiveQueueStore(),
 		)
 
 		playerID := uuid.New()
@@ -117,6 +118,7 @@ func TestMatchmakingEventConsumer_HandleQueueEvent(t *testing.T) {
 			mockRegionReader,
 			mockPoolReader,
 			mockPoolWriter,
+			pairing_entities.NewInMemoryActiveQueueStore(),
 		)
 
 		playerID := uuid.New()
@@ -163,6 +165,7 @@ func TestMatchmakingEventConsumer_HandleQueueEvent(t *testing.T) {
 			mockRegionReader,
 			mockPoolReader,
 			mockPoolWriter,
+			pairing_entities.NewInMemoryActiveQueueStore(),
 		)
 
 		playerID := uuid.New()
@@ -201,6 +204,7 @@ func TestMatchmakingEventConsumer_HandleQueueEvent(t *testing.T) {
 			mockRegionReader,
 			mockPoolReader,
 			mockPoolWriter,
+			pairing_entities.NewInMemoryActiveQueueStore(),
 		)
 
 		playerID := uuid.New()
@@ -235,6 +239,7 @@ func TestMatchmakingEventConsumer_HandleQueueEvent(t *testing.T) {
 			mockRegionReader,
 			mockPoolReader,
 			mockPoolWriter,
+			pairing_entities.NewInMemoryActiveQueueStore(),
 		)
 
 		playerID := uuid.New()
@@ -286,6 +291,7 @@ func TestMatchmakingEventConsumer_HandleQueueEvent(t *testing.T) {
 			mockRegionReader,
 			mockPoolReader,
 			mockPoolWriter,
+			pairing_entities.NewInMemoryActiveQueueStore(),
 		)
 
 		playerID := uuid.New()
@@ -330,6 +336,7 @@ func TestMatchmakingEventConsumer_HandleQueueEvent(t *testing.T) {
 			mockRegionReader,
 			mockPoolReader,
 			mockPoolWriter,
+			pairing_entities.NewInMemoryActiveQueueStore(),
 		)
 
 		event := &kafka.QueueEvent{
@@ -357,6 +364,7 @@ func TestMatchmakingEventConsumer_HandleQueueEvent(t *testing.T) {
 			mockRegionReader,
 			mockPoolReader,
 			mockPoolWriter,
+			pairing_entities.NewInMemoryActiveQueueStore(),
 		)
 
 		playerID := uuid.New()
@@ -395,6 +403,7 @@ func TestMatchmakingEventConsumer_HandleQueueEvent(t *testing.T) {
 			mockRegionReader,
 			mockPoolReader,
 			mockPoolWriter,
+			pairing_entities.NewInMemoryActiveQueueStore(),
 		)
 
 		playerID := uuid.New()
@@ -447,6 +456,7 @@ func TestMatchmakingEventConsumer_HandleQueueEvent(t *testing.T) {
 			mockRegionReader,
 			mockPoolReader,
 			mockPoolWriter,
+			pairing_entities.NewInMemoryActiveQueueStore(),
 		)
 
 		playerID := uuid.New()
@@ -508,6 +518,7 @@ func TestMatchmakingEventConsumer_HandleQueueEvent(t *testing.T) {
 			mockRegionReader,
 			mockPoolReader,
 			mockPoolWriter,
+			pairing_entities.NewInMemoryActiveQueueStore(),
 		)
 
 		lobbyID := uuid.New()
@@ -542,6 +553,7 @@ func TestMatchmakingEventConsumer_HandleQueueEvent(t *testing.T) {
 			mockRegionReader,
 			mockPoolReader,
 			mockPoolWriter,
+			pairing_entities.NewInMemoryActiveQueueStore(),
 		)
 
 		event := &kafka.LobbyEvent{
@@ -564,6 +576,7 @@ func newTestConsumer() (*usecases.MatchmakingEventConsumer, *MockAddAndFindNextP
 	mockRegionReader := &mocks.MockPortRegionReader{}
 	mockPoolReader := &mocks.MockPoolReader{}
 	mockPoolWriter := &mocks.MockPoolWriter{}
+	activeQueueStore := pairing_entities.NewInMemoryActiveQueueStore()
 
 	consumer := usecases.NewMatchmakingEventConsumer(
 		mockAddAndFind,
@@ -571,6 +584,7 @@ func newTestConsumer() (*usecases.MatchmakingEventConsumer, *MockAddAndFindNextP
 		mockRegionReader,
 		mockPoolReader,
 		mockPoolWriter,
+		activeQueueStore,
 	)
 
 	return consumer, mockAddAndFind, mockEventPublisher, mockRegionReader

--- a/pkg/domain/pairing/usecases/queue_status_ticker.go
+++ b/pkg/domain/pairing/usecases/queue_status_ticker.go
@@ -1,0 +1,204 @@
+package usecases
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	pairing_entities "github.com/leet-gaming/match-making-api/pkg/domain/pairing/entities"
+	pairing_out "github.com/leet-gaming/match-making-api/pkg/domain/pairing/ports/out"
+	pairing_value_objects "github.com/leet-gaming/match-making-api/pkg/domain/pairing/value-objects"
+	game_out "github.com/leet-gaming/match-making-api/pkg/domain/game/ports/out"
+	"github.com/leet-gaming/match-making-api/pkg/infra/kafka"
+)
+
+// QueueStatusTickerConfig holds configuration for the periodic queue status updater.
+type QueueStatusTickerConfig struct {
+	// Interval between position update broadcasts (default: 5 seconds)
+	Interval time.Duration
+
+	// EstimatedWaitPerPosition is the estimated wait time per position in the queue.
+	// Used to derive estimated_wait_ms for the client (default: 10 seconds per position).
+	EstimatedWaitPerPosition time.Duration
+
+	// Enabled controls whether the ticker is active. Can be toggled at runtime via feature flag.
+	Enabled bool
+}
+
+// DefaultQueueStatusTickerConfig returns sensible defaults for the queue status ticker.
+func DefaultQueueStatusTickerConfig() *QueueStatusTickerConfig {
+	return &QueueStatusTickerConfig{
+		Interval:                 5 * time.Second,
+		EstimatedWaitPerPosition: 10 * time.Second,
+		Enabled:                  true,
+	}
+}
+
+// QueueStatusTicker periodically scans active queue entries and publishes
+// QueueStatusUpdated events via Kafka for WebSocket broadcast to players.
+//
+// Architecture: match-making-api is the source of truth for pool state, so it
+// produces these events. replay-api (or another service) consumes from
+// websocket.broadcasts and delivers to the player's WebSocket connection.
+type QueueStatusTicker struct {
+	activeQueueStore pairing_out.ActiveQueueStore
+	poolReader       pairing_out.PoolReader
+	regionReader     game_out.RegionReader
+	eventPublisher   *kafka.EventPublisher
+	config           *QueueStatusTickerConfig
+}
+
+// NewQueueStatusTicker creates a new ticker for periodic queue status broadcasts.
+func NewQueueStatusTicker(
+	activeQueueStore pairing_out.ActiveQueueStore,
+	poolReader pairing_out.PoolReader,
+	regionReader game_out.RegionReader,
+	eventPublisher *kafka.EventPublisher,
+	config *QueueStatusTickerConfig,
+) *QueueStatusTicker {
+	if config == nil {
+		config = DefaultQueueStatusTickerConfig()
+	}
+	return &QueueStatusTicker{
+		activeQueueStore: activeQueueStore,
+		poolReader:       poolReader,
+		regionReader:     regionReader,
+		eventPublisher:   eventPublisher,
+		config:           config,
+	}
+}
+
+// Start begins the periodic ticker. It blocks until the context is cancelled.
+func (t *QueueStatusTicker) Start(ctx context.Context) error {
+	if !t.config.Enabled {
+		slog.Info("QueueStatusTicker is disabled, not starting")
+		return nil
+	}
+
+	slog.Info("Starting QueueStatusTicker",
+		"interval", t.config.Interval,
+		"estimated_wait_per_position", t.config.EstimatedWaitPerPosition)
+
+	ticker := time.NewTicker(t.config.Interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Info("QueueStatusTicker stopped (context cancelled)")
+			return nil
+		case <-ticker.C:
+			t.tick(ctx)
+		}
+	}
+}
+
+// tick performs a single iteration: scans all active queue entries,
+// refreshes positions from pool state, and publishes status events.
+func (t *QueueStatusTicker) tick(ctx context.Context) {
+	entries, err := t.activeQueueStore.GetAll(ctx)
+	if err != nil {
+		slog.WarnContext(ctx, "Failed to get active queue entries", "error", err)
+		return
+	}
+	if len(entries) == 0 {
+		return
+	}
+
+	slog.Debug("QueueStatusTicker tick", "active_players", len(entries))
+
+	for _, entry := range entries {
+		// Refresh position from pool state
+		position := t.refreshPosition(ctx, entry)
+		if position < 0 {
+			// Player no longer in pool — remove from active queue
+			if err := t.activeQueueStore.Remove(ctx, entry.PlayerID); err != nil {
+				slog.WarnContext(ctx, "Failed to remove player from active queue",
+					"player_id", entry.PlayerID, "error", err)
+			}
+			slog.InfoContext(ctx, "Player no longer in pool, removed from active queue",
+				"player_id", entry.PlayerID)
+			continue
+		}
+
+		// Update stored position
+		if _, err := t.activeQueueStore.UpdatePosition(ctx, entry.PlayerID, position); err != nil {
+			slog.WarnContext(ctx, "Failed to update player position",
+				"player_id", entry.PlayerID, "error", err)
+		}
+
+		// Compute estimated wait
+		estimatedWaitMs := int64(position) * t.config.EstimatedWaitPerPosition.Milliseconds()
+
+		// Count total players in queue for this game/region
+		totalInQueue := t.countPlayersInQueue(entries, entry.GameID, entry.RegionSlug)
+
+		// Publish WebSocket broadcast event targeted at this player
+		if t.eventPublisher == nil {
+			continue
+		}
+
+		payload := &kafka.QueueStatusPayload{
+			PlayerID:        entry.PlayerID,
+			GameID:          entry.GameID,
+			Region:          entry.RegionSlug,
+			Position:        position,
+			EstimatedWaitMs: estimatedWaitMs,
+			TotalInQueue:    totalInQueue,
+			EventType:       kafka.EventTypeQueueStatusUpdated,
+			Timestamp:       time.Now().UnixMilli(),
+		}
+
+		broadcastEvent := &kafka.WebSocketBroadcastEvent{
+			Type:      kafka.EventTypeQueueStatusUpdated,
+			TargetIDs: []uuid.UUID{entry.PlayerID},
+			Payload:   payload,
+			Timestamp: time.Now().UnixMilli(),
+		}
+
+		if err := t.eventPublisher.PublishWebSocketBroadcast(ctx, broadcastEvent); err != nil {
+			slog.WarnContext(ctx, "Failed to publish queue status update",
+				"player_id", entry.PlayerID,
+				"error", err)
+		}
+	}
+}
+
+// refreshPosition looks up the player's current position in the pool.
+// Returns -1 if the player is no longer in any pool.
+func (t *QueueStatusTicker) refreshPosition(ctx context.Context, entry *pairing_entities.ActiveQueueEntry) int {
+	// Build criteria to find the pool
+	regions, err := t.regionReader.Search(ctx, map[string]interface{}{"slug": entry.RegionSlug})
+	if err != nil || len(regions) == 0 {
+		return -1
+	}
+
+	criteria := &pairing_value_objects.Criteria{
+		GameID: &entry.GameID,
+		Region: regions[0],
+	}
+
+	pool, err := t.poolReader.FindPool(criteria)
+	if err != nil || pool == nil {
+		return -1
+	}
+
+	pos, found := pool.IsQueued(entry.PlayerID)
+	if !found {
+		return -1
+	}
+
+	return pos + 1 // IsQueued returns 0-based index; position is 1-based
+}
+
+// countPlayersInQueue counts how many active entries share the same game and region.
+func (t *QueueStatusTicker) countPlayersInQueue(entries []*pairing_entities.ActiveQueueEntry, gameID uuid.UUID, regionSlug string) int {
+	count := 0
+	for _, e := range entries {
+		if e.GameID == gameID && e.RegionSlug == regionSlug {
+			count++
+		}
+	}
+	return count
+}

--- a/pkg/domain/pairing/usecases/queue_status_ticker_test.go
+++ b/pkg/domain/pairing/usecases/queue_status_ticker_test.go
@@ -1,0 +1,259 @@
+package usecases_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	game_entities "github.com/leet-gaming/match-making-api/pkg/domain/game/entities"
+	pairing_entities "github.com/leet-gaming/match-making-api/pkg/domain/pairing/entities"
+	"github.com/leet-gaming/match-making-api/pkg/domain/pairing/usecases"
+	"github.com/leet-gaming/match-making-api/test/mocks"
+)
+
+func TestQueueStatusTicker_Disabled(t *testing.T) {
+	store := pairing_entities.NewInMemoryActiveQueueStore()
+
+	cfg := &usecases.QueueStatusTickerConfig{
+		Interval:                 100 * time.Millisecond,
+		EstimatedWaitPerPosition: 10 * time.Second,
+		Enabled:                  false,
+	}
+
+	ticker := usecases.NewQueueStatusTicker(store, nil, nil, nil, cfg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	err := ticker.Start(ctx)
+	assert.NoError(t, err, "disabled ticker should return immediately without error")
+}
+
+func TestQueueStatusTicker_EmptyQueue(t *testing.T) {
+	store := pairing_entities.NewInMemoryActiveQueueStore()
+	mockRegionReader := &mocks.MockPortRegionReader{}
+	mockPoolReader := &mocks.MockPoolReader{}
+
+	cfg := &usecases.QueueStatusTickerConfig{
+		Interval:                 50 * time.Millisecond,
+		EstimatedWaitPerPosition: 10 * time.Second,
+		Enabled:                  true,
+	}
+
+	ticker := usecases.NewQueueStatusTicker(store, mockPoolReader, mockRegionReader, nil, cfg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	err := ticker.Start(ctx)
+	assert.NoError(t, err)
+
+	mockRegionReader.AssertNotCalled(t, "Search", mock.Anything, mock.Anything)
+}
+
+func TestQueueStatusTicker_RefreshesPosition(t *testing.T) {
+	ctx := context.Background()
+	store := pairing_entities.NewInMemoryActiveQueueStore()
+	mockRegionReader := &mocks.MockPortRegionReader{}
+	mockPoolReader := &mocks.MockPoolReader{}
+
+	playerID := uuid.New()
+	gameID := uuid.New()
+	regionSlug := "us-east-1"
+
+	region := &game_entities.Region{
+		Name: "US East",
+		Slug: regionSlug,
+	}
+	region.ID = uuid.New()
+
+	_ = store.Register(ctx, &pairing_entities.ActiveQueueEntry{
+		PlayerID:        playerID,
+		GameID:          gameID,
+		RegionSlug:      regionSlug,
+		TenantID:        uuid.New().String(),
+		ClientID:        uuid.New().String(),
+		ResourceOwnerID: uuid.New().String(),
+		Position:        10,
+		JoinedAt:        time.Now().UTC(),
+	})
+
+	mockRegionReader.On("Search", mock.Anything, map[string]interface{}{"slug": regionSlug}).Return([]*game_entities.Region{region}, nil)
+
+	pool := &pairing_entities.Pool{
+		Parties: []uuid.UUID{uuid.New(), playerID, uuid.New()},
+	}
+	mockPoolReader.On("FindPool", mock.Anything).Return(pool, nil)
+
+	cfg := &usecases.QueueStatusTickerConfig{
+		Interval:                 50 * time.Millisecond,
+		EstimatedWaitPerPosition: 10 * time.Second,
+		Enabled:                  true,
+	}
+
+	ticker := usecases.NewQueueStatusTicker(store, mockPoolReader, mockRegionReader, nil, cfg)
+
+	tickerCtx, cancel := context.WithTimeout(ctx, 150*time.Millisecond)
+	defer cancel()
+
+	_ = ticker.Start(tickerCtx)
+
+	mockRegionReader.AssertCalled(t, "Search", mock.Anything, map[string]interface{}{"slug": regionSlug})
+	mockPoolReader.AssertCalled(t, "FindPool", mock.Anything)
+
+	entry, _ := store.Get(ctx, playerID)
+	assert.NotNil(t, entry)
+	assert.Equal(t, 2, entry.Position, "Position should be refreshed from pool state (1-based)")
+}
+
+func TestQueueStatusTicker_RemovesPlayerNotInPool(t *testing.T) {
+	ctx := context.Background()
+	store := pairing_entities.NewInMemoryActiveQueueStore()
+	mockRegionReader := &mocks.MockPortRegionReader{}
+	mockPoolReader := &mocks.MockPoolReader{}
+
+	playerID := uuid.New()
+	gameID := uuid.New()
+	regionSlug := "eu-west-1"
+
+	region := &game_entities.Region{
+		Name: "EU West",
+		Slug: regionSlug,
+	}
+	region.ID = uuid.New()
+
+	_ = store.Register(ctx, &pairing_entities.ActiveQueueEntry{
+		PlayerID:   playerID,
+		GameID:     gameID,
+		RegionSlug: regionSlug,
+		Position:   1,
+		JoinedAt:   time.Now().UTC(),
+	})
+
+	mockRegionReader.On("Search", mock.Anything, map[string]interface{}{"slug": regionSlug}).Return([]*game_entities.Region{region}, nil)
+
+	pool := &pairing_entities.Pool{
+		Parties: []uuid.UUID{uuid.New()},
+	}
+	mockPoolReader.On("FindPool", mock.Anything).Return(pool, nil)
+
+	cfg := &usecases.QueueStatusTickerConfig{
+		Interval:                 50 * time.Millisecond,
+		EstimatedWaitPerPosition: 10 * time.Second,
+		Enabled:                  true,
+	}
+
+	ticker := usecases.NewQueueStatusTicker(store, mockPoolReader, mockRegionReader, nil, cfg)
+
+	tickerCtx, cancel := context.WithTimeout(ctx, 150*time.Millisecond)
+	defer cancel()
+
+	_ = ticker.Start(tickerCtx)
+
+	got, _ := store.Get(ctx, playerID)
+	assert.Nil(t, got, "Player not in pool should be removed from active queue")
+
+	count, _ := store.Count(ctx)
+	assert.Equal(t, 0, count)
+}
+
+func TestQueueStatusTicker_PoolNotFound(t *testing.T) {
+	ctx := context.Background()
+	store := pairing_entities.NewInMemoryActiveQueueStore()
+	mockRegionReader := &mocks.MockPortRegionReader{}
+	mockPoolReader := &mocks.MockPoolReader{}
+
+	playerID := uuid.New()
+	gameID := uuid.New()
+	regionSlug := "ap-south-1"
+
+	region := &game_entities.Region{
+		Name: "AP South",
+		Slug: regionSlug,
+	}
+	region.ID = uuid.New()
+
+	_ = store.Register(ctx, &pairing_entities.ActiveQueueEntry{
+		PlayerID:   playerID,
+		GameID:     gameID,
+		RegionSlug: regionSlug,
+		Position:   1,
+		JoinedAt:   time.Now().UTC(),
+	})
+
+	mockRegionReader.On("Search", mock.Anything, map[string]interface{}{"slug": regionSlug}).Return([]*game_entities.Region{region}, nil)
+	mockPoolReader.On("FindPool", mock.Anything).Return((*pairing_entities.Pool)(nil), nil)
+
+	cfg := &usecases.QueueStatusTickerConfig{
+		Interval:                 50 * time.Millisecond,
+		EstimatedWaitPerPosition: 10 * time.Second,
+		Enabled:                  true,
+	}
+
+	ticker := usecases.NewQueueStatusTicker(store, mockPoolReader, mockRegionReader, nil, cfg)
+
+	tickerCtx, cancel := context.WithTimeout(ctx, 150*time.Millisecond)
+	defer cancel()
+
+	_ = ticker.Start(tickerCtx)
+
+	got, _ := store.Get(ctx, playerID)
+	assert.Nil(t, got, "Player should be removed when pool not found")
+}
+
+func TestQueueStatusTicker_RegionNotFound(t *testing.T) {
+	ctx := context.Background()
+	store := pairing_entities.NewInMemoryActiveQueueStore()
+	mockRegionReader := &mocks.MockPortRegionReader{}
+	mockPoolReader := &mocks.MockPoolReader{}
+
+	playerID := uuid.New()
+	gameID := uuid.New()
+	regionSlug := "unknown-region"
+
+	_ = store.Register(ctx, &pairing_entities.ActiveQueueEntry{
+		PlayerID:   playerID,
+		GameID:     gameID,
+		RegionSlug: regionSlug,
+		Position:   1,
+		JoinedAt:   time.Now().UTC(),
+	})
+
+	mockRegionReader.On("Search", mock.Anything, map[string]interface{}{"slug": regionSlug}).Return([]*game_entities.Region{}, nil)
+
+	cfg := &usecases.QueueStatusTickerConfig{
+		Interval:                 50 * time.Millisecond,
+		EstimatedWaitPerPosition: 10 * time.Second,
+		Enabled:                  true,
+	}
+
+	ticker := usecases.NewQueueStatusTicker(store, mockPoolReader, mockRegionReader, nil, cfg)
+
+	tickerCtx, cancel := context.WithTimeout(ctx, 150*time.Millisecond)
+	defer cancel()
+
+	_ = ticker.Start(tickerCtx)
+
+	got, _ := store.Get(ctx, playerID)
+	assert.Nil(t, got, "Player should be removed when region not found")
+	mockPoolReader.AssertNotCalled(t, "FindPool", mock.Anything)
+}
+
+func TestDefaultQueueStatusTickerConfig(t *testing.T) {
+	cfg := usecases.DefaultQueueStatusTickerConfig()
+
+	assert.Equal(t, 5*time.Second, cfg.Interval)
+	assert.Equal(t, 10*time.Second, cfg.EstimatedWaitPerPosition)
+	assert.True(t, cfg.Enabled)
+}
+
+func TestQueueStatusTicker_NilConfig(t *testing.T) {
+	store := pairing_entities.NewInMemoryActiveQueueStore()
+
+	ticker := usecases.NewQueueStatusTicker(store, nil, nil, nil, nil)
+	assert.NotNil(t, ticker, "should use default config when nil is passed")
+}

--- a/pkg/domain/worker_container.go
+++ b/pkg/domain/worker_container.go
@@ -1,0 +1,17 @@
+package domain
+
+import (
+	"github.com/golobby/container/v3"
+	"github.com/leet-gaming/match-making-api/pkg/common"
+	"github.com/leet-gaming/match-making-api/pkg/domain/game"
+	"github.com/leet-gaming/match-making-api/pkg/domain/pairing"
+	"github.com/leet-gaming/match-making-api/pkg/domain/schedules"
+)
+
+// InjectWorker sets up only the domain dependencies needed by background workers.
+// It skips IAM and lobbies which are only needed by the REST API.
+//
+// Includes: game (regions), pairing (consumer, ticker, pools), schedules (party matcher).
+func InjectWorker(c container.Container) error {
+	return common.InjectAll(c, game.Inject, pairing.Inject, schedules.Inject)
+}

--- a/pkg/infra/cache/active_queue_redis.go
+++ b/pkg/infra/cache/active_queue_redis.go
@@ -1,0 +1,197 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/leet-gaming/match-making-api/pkg/domain/pairing/entities"
+	pairing_out "github.com/leet-gaming/match-making-api/pkg/domain/pairing/ports/out"
+)
+
+// Ensure RedisActiveQueueStore implements the port interface.
+var _ pairing_out.ActiveQueueStore = (*RedisActiveQueueStore)(nil)
+
+// RedisActiveQueueStore is a Redis/Dragonfly-backed implementation of ActiveQueueStore.
+// Each player entry is stored as a JSON hash value keyed by player ID.
+// A Redis Set tracks all active player IDs for efficient GetAll/Count operations.
+//
+// Key structure:
+//
+//	matchmaking:active_queue:<player_id>  → JSON of ActiveQueueEntry
+//	matchmaking:active_queue:players      → Set of player_id strings
+//
+// TTL: entries expire after 10 minutes to auto-clean stale data.
+type RedisActiveQueueStore struct {
+	client *redis.Client
+	ttl    time.Duration
+}
+
+// NewRedisActiveQueueStore creates a new Redis-backed ActiveQueueStore.
+func NewRedisActiveQueueStore(client *redis.Client) *RedisActiveQueueStore {
+	return &RedisActiveQueueStore{
+		client: client,
+		ttl:    10 * time.Minute,
+	}
+}
+
+func (s *RedisActiveQueueStore) Register(ctx context.Context, entry *entities.ActiveQueueEntry) error {
+	playerID := entry.PlayerID.String()
+	key := PlayerKey(playerID)
+
+	// Preserve original JoinedAt if player already registered
+	existing, err := s.Get(ctx, entry.PlayerID)
+	if err != nil {
+		return fmt.Errorf("failed to check existing entry: %w", err)
+	}
+	if existing != nil {
+		entry.JoinedAt = existing.JoinedAt
+	}
+
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("failed to marshal entry: %w", err)
+	}
+
+	pipe := s.client.Pipeline()
+	pipe.Set(ctx, key, data, s.ttl)
+	pipe.SAdd(ctx, ActiveQueueSetKey, playerID)
+	_, err = pipe.Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to register player %s: %w", playerID, err)
+	}
+
+	return nil
+}
+
+func (s *RedisActiveQueueStore) Remove(ctx context.Context, playerID uuid.UUID) error {
+	pid := playerID.String()
+	key := PlayerKey(pid)
+
+	pipe := s.client.Pipeline()
+	pipe.Del(ctx, key)
+	pipe.SRem(ctx, ActiveQueueSetKey, pid)
+	_, err := pipe.Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to remove player %s: %w", pid, err)
+	}
+
+	return nil
+}
+
+func (s *RedisActiveQueueStore) Get(ctx context.Context, playerID uuid.UUID) (*entities.ActiveQueueEntry, error) {
+	key := PlayerKey(playerID.String())
+
+	data, err := s.client.Get(ctx, key).Bytes()
+	if err == redis.Nil {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get player %s: %w", playerID, err)
+	}
+
+	var entry entities.ActiveQueueEntry
+	if err := json.Unmarshal(data, &entry); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal entry for player %s: %w", playerID, err)
+	}
+
+	return &entry, nil
+}
+
+func (s *RedisActiveQueueStore) GetAll(ctx context.Context) ([]*entities.ActiveQueueEntry, error) {
+	memberIDs, err := s.client.SMembers(ctx, ActiveQueueSetKey).Result()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get active player set: %w", err)
+	}
+
+	if len(memberIDs) == 0 {
+		return nil, nil
+	}
+
+	// Build keys for pipeline get
+	keys := make([]string, len(memberIDs))
+	for i, pid := range memberIDs {
+		keys[i] = PlayerKey(pid)
+	}
+
+	values, err := s.client.MGet(ctx, keys...).Result()
+	if err != nil {
+		return nil, fmt.Errorf("failed to mget active queue entries: %w", err)
+	}
+
+	entries := make([]*entities.ActiveQueueEntry, 0, len(values))
+	staleIDs := make([]string, 0)
+
+	for i, val := range values {
+		if val == nil {
+			// Entry expired but still in set — mark for cleanup
+			staleIDs = append(staleIDs, memberIDs[i])
+			continue
+		}
+
+		str, ok := val.(string)
+		if !ok {
+			slog.Warn("Unexpected value type in active queue", "player_id", memberIDs[i])
+			continue
+		}
+
+		var entry entities.ActiveQueueEntry
+		if err := json.Unmarshal([]byte(str), &entry); err != nil {
+			slog.Warn("Failed to unmarshal active queue entry", "player_id", memberIDs[i], "error", err)
+			staleIDs = append(staleIDs, memberIDs[i])
+			continue
+		}
+
+		entries = append(entries, &entry)
+	}
+
+	// Cleanup stale entries from the set (TTL expired but set entry remained)
+	if len(staleIDs) > 0 {
+		ifaces := make([]interface{}, len(staleIDs))
+		for i, id := range staleIDs {
+			ifaces[i] = id
+		}
+		if err := s.client.SRem(ctx, ActiveQueueSetKey, ifaces...).Err(); err != nil {
+			slog.Warn("Failed to cleanup stale active queue set entries", "error", err)
+		}
+	}
+
+	return entries, nil
+}
+
+func (s *RedisActiveQueueStore) Count(ctx context.Context) (int, error) {
+	count, err := s.client.SCard(ctx, ActiveQueueSetKey).Result()
+	if err != nil {
+		return 0, fmt.Errorf("failed to count active queue: %w", err)
+	}
+	return int(count), nil
+}
+
+func (s *RedisActiveQueueStore) UpdatePosition(ctx context.Context, playerID uuid.UUID, position int) (bool, error) {
+	entry, err := s.Get(ctx, playerID)
+	if err != nil {
+		return false, err
+	}
+	if entry == nil {
+		return false, nil
+	}
+
+	entry.Position = position
+
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return false, fmt.Errorf("failed to marshal updated entry: %w", err)
+	}
+
+	key := PlayerKey(playerID.String())
+	if err := s.client.Set(ctx, key, data, s.ttl).Err(); err != nil {
+		return false, fmt.Errorf("failed to update position for player %s: %w", playerID, err)
+	}
+
+	return true, nil
+}

--- a/pkg/infra/cache/redis.go
+++ b/pkg/infra/cache/redis.go
@@ -1,0 +1,54 @@
+package cache
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// RedisConfig holds connection settings for Redis/Dragonfly.
+type RedisConfig struct {
+	Addr     string
+	Password string
+	DB       int
+}
+
+// NewRedisConfigFromEnv reads Redis connection config from environment variables.
+func NewRedisConfigFromEnv() *RedisConfig {
+	addr := os.Getenv("REDIS_ADDR")
+	if addr == "" {
+		addr = "localhost:6379"
+	}
+	password := os.Getenv("REDIS_PASSWORD")
+	return &RedisConfig{
+		Addr:     addr,
+		Password: password,
+		DB:       0,
+	}
+}
+
+// NewRedisClient creates a new Redis client from the given config.
+func NewRedisClient(cfg *RedisConfig) (*redis.Client, error) {
+	client := redis.NewClient(&redis.Options{
+		Addr:     cfg.Addr,
+		Password: cfg.Password,
+		DB:       cfg.DB,
+	})
+
+	slog.Info("Redis client created", "addr", cfg.Addr)
+
+	return client, nil
+}
+
+// ActiveQueueKeyPrefix is the Redis key prefix for active queue entries.
+const ActiveQueueKeyPrefix = "matchmaking:active_queue:"
+
+// ActiveQueueSetKey is the Redis key for the set of all active player IDs.
+const ActiveQueueSetKey = "matchmaking:active_queue:players"
+
+// PlayerKey returns the Redis key for a specific player's queue entry.
+func PlayerKey(playerID string) string {
+	return fmt.Sprintf("%s%s", ActiveQueueKeyPrefix, playerID)
+}

--- a/pkg/infra/container.go
+++ b/pkg/infra/container.go
@@ -19,5 +19,5 @@ import (
 // Returns:
 //   - error: An error if the injection process fails, nil otherwise.
 func Inject(c container.Container) error {
-	return common.InjectAll(c, ioc.InjectIoc, mongodb.InjectGameRepository, mongodb.InjectGameModeRepository, mongodb.InjectRegionRepository, squad.Inject, billing.Inject, iam.Inject, InjectKafka)
+	return common.InjectAll(c, ioc.InjectIoc, mongodb.InjectGameRepository, mongodb.InjectGameModeRepository, mongodb.InjectRegionRepository, squad.Inject, billing.Inject, iam.Inject, InjectKafka, InjectRedis)
 }

--- a/pkg/infra/kafka/events.go
+++ b/pkg/infra/kafka/events.go
@@ -40,7 +40,21 @@ const (
 	EventTypeMatchStarted       = "MATCH_STARTED"
 	EventTypeMatchCompleted     = "MATCH_COMPLETED"
 	EventTypeMatchCancelled     = "MATCH_CANCELLED"
+	EventTypeQueueStatusUpdated = "QUEUE_STATUS_UPDATED"
 )
+
+// QueueStatusPayload is the payload for QUEUE_STATUS_UPDATED events.
+// Broadcast via WebSocket to the player to show live queue position changes.
+type QueueStatusPayload struct {
+	PlayerID        uuid.UUID `json:"player_id"`
+	GameID          uuid.UUID `json:"game_id"`
+	Region          string    `json:"region"`
+	Position        int       `json:"position"`
+	EstimatedWaitMs int64     `json:"estimated_wait_ms"`
+	TotalInQueue    int       `json:"total_in_queue"`
+	EventType       string    `json:"event_type"`
+	Timestamp       int64     `json:"timestamp"`
+}
 
 // EventPublisher publishes domain events to Kafka topics
 type EventPublisher struct {

--- a/pkg/infra/redis.go
+++ b/pkg/infra/redis.go
@@ -1,0 +1,15 @@
+package infra
+
+import (
+	"github.com/golobby/container/v3"
+	"github.com/leet-gaming/match-making-api/pkg/infra/cache"
+	"github.com/redis/go-redis/v9"
+)
+
+// InjectRedis sets up the Redis/Dragonfly client in the container.
+func InjectRedis(c container.Container) error {
+	return c.Singleton(func() (*redis.Client, error) {
+		cfg := cache.NewRedisConfigFromEnv()
+		return cache.NewRedisClient(cfg)
+	})
+}

--- a/pkg/infra/worker_container.go
+++ b/pkg/infra/worker_container.go
@@ -1,0 +1,24 @@
+package infra
+
+import (
+	"github.com/golobby/container/v3"
+	"github.com/leet-gaming/match-making-api/pkg/common"
+	"github.com/leet-gaming/match-making-api/pkg/infra/db/mongodb"
+	"github.com/leet-gaming/match-making-api/pkg/infra/ioc"
+)
+
+// InjectWorker sets up only the infrastructure needed by background workers
+// (consumers and tickers). It skips IAM, billing, squad, and other
+// HTTP-specific dependencies that workers don't need.
+//
+// Includes: MongoDB (regions, game repos), Kafka, Redis.
+func InjectWorker(c container.Container) error {
+	return common.InjectAll(c,
+		ioc.InjectIoc,
+		mongodb.InjectGameRepository,
+		mongodb.InjectGameModeRepository,
+		mongodb.InjectRegionRepository,
+		InjectKafka,
+		InjectRedis,
+	)
+}


### PR DESCRIPTION
## Summary

This PR implements **real-time queue position updates** for the matchmaking system, including a distributed `ActiveQueueStore` backed by Dragonfly/Redis, a periodic `QueueStatusTicker` that broadcasts position updates via Kafka, and an architectural refactor to separate the REST API from background workers into independent binaries.

## Key Features Added

### Queue Position Updates (Real-Time)

- **QueueStatusTicker**: Periodic process (configurable, default 5s) that scans all active queue entries, refreshes positions from pool state, and publishes `QueueStatusUpdated` events to `websocket.broadcasts` topic for WebSocket delivery.
- **ActiveQueueStore (Interface)**: Port interface (`pairing_out.ActiveQueueStore`) with `Register`, `Remove`, `Get`, `GetAll`, `Count`, `UpdatePosition` methods — decouples domain from storage implementation.
- **RedisActiveQueueStore**: Production implementation backed by Dragonfly/Redis. Uses pipelines for atomic operations, a Redis Set for efficient `GetAll`/`Count`, TTL-based auto-cleanup (10 min), and stale entry reconciliation.
- **InMemoryActiveQueueStore**: Lightweight implementation for unit tests.
- **QueueStatusPayload**: Event schema with `player_id`, `game_id`, `region`, `position`, `estimated_wait_ms`, `total_in_queue`.

### PlayerQueued Event Handling

- **PlayerQueuedConsumer**: Kafka consumer for `matchmaking.commands` topic, deserializes protobuf `EventEnvelope`, validates CloudEvents 1.0 fields and resource ownership (`resource_owner_id`, `tenant_id`, `client_id`, `player_id`), then delegates to domain handler.
- **HandlePlayerQueuedProto**: Domain handler that adds players to the matchmaking pool via `AddAndFindNextPairUseCase`, registers them in `ActiveQueueStore` on join, and removes matched players on pair creation.

### Infrastructure Improvements

- **Separate Worker Binary**: `cmd/workers/matchmaking/main.go` — runs `PlayerQueuedConsumer` + `QueueStatusTicker` in a single process with shared `ActiveQueueStore` via Redis. Includes graceful shutdown on `SIGINT`/`SIGTERM`.
- **Slim DI Injection**: `infra.InjectWorker` and `domain.InjectWorker` load only what the worker needs (MongoDB, Kafka, Redis, game, pairing, schedules) — skips IAM, billing, squad, lobbies.
- **Dragonfly Integration**: New Redis/Dragonfly client (`pkg/infra/cache/`) configured via `REDIS_ADDR` and `REDIS_PASSWORD` environment variables.
- **Multi-stage Dockerfile**: Builds both `match-making-api` (REST) and `matchmaking-worker` as separate targets from a single Dockerfile.
- **Docker Compose**: Added `dragonfly` and `matchmaking-worker` services to both `docker-compose.dev.yml` and `docker-compose.yml.example`.

## Architecture Highlights

**Design Patterns:**
- **Ports & Adapters (Hexagonal)**: `ActiveQueueStore` is a domain port with two adapters (in-memory for tests, Redis for production). Domain code never imports infrastructure directly.
- **Process Separation**: REST API and background workers are independent binaries sharing the same `pkg/` codebase but with different DI containers, enabling independent scaling and deployment.

**Key Components:**
- `QueueStatusTicker` → reads `ActiveQueueStore` → refreshes from `PoolReader` → publishes to Kafka `websocket.broadcasts`
- `PlayerQueuedConsumer` → validates CloudEvents envelope → calls `HandlePlayerQueuedProto` → updates pool + `ActiveQueueStore`
- `RedisActiveQueueStore` → Redis keys per player + Set for membership tracking → distributed state across processes

**Security & Best Practices:**
- Resource ownership validation on every `PlayerQueued` event (envelope + payload fields)
- Nil-safe event publisher in ticker (graceful degradation if Kafka unavailable)
- TTL-based expiry on Redis entries prevents stale queue state accumulation

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test addition or update

## Related Issue

Closes #22

## Test Plan

- [x] Build project: `go build ./...`
- [x] Run unit tests: `go test ./...`
- [ ] Run integration tests (if applicable)
- [ ] Manual testing performed
- [ ] All API endpoints tested
- [x] Error handling verified
- [x] Edge cases tested
- [ ] Performance tested (if applicable)
- [x] Security checks performed
- [x] No sensitive data in commits

### Test Steps

1. `go build ./...` — verify both binaries compile
2. `go test ./pkg/domain/pairing/entities/...` — 8 tests for `InMemoryActiveQueueStore` (register, idempotent re-register, remove, get all copies, update position, count)
3. `go test ./pkg/domain/pairing/usecases/...` — 8 tests for `QueueStatusTicker` (disabled, empty queue, position refresh, player removal when not in pool, pool not found, region not found, default config, nil config) + 7 tests for `HandlePlayerQueuedProto` (successful add, successful match, missing resource owner, invalid UUIDs, region not found, AddAndFindNextPair failure)
4. `go test ./pkg/infra/kafka/...` — 11 tests for `PlayerQueuedConsumer` (valid event dispatch, malformed messages, nil envelope, resource ownership validation failures) + 5 tests for `validateResourceOwnership`
5. `docker-compose -f docker-compose.dev.yml up -d` — verify all services start (API, worker, MongoDB, Kafka, Dragonfly)

## Files Changed

- 69 files changed
- 5393 insertions(+)
- 2191 deletions(-)

## Database Migration

N/A — `ActiveQueueStore` uses Redis/Dragonfly (no MongoDB schema changes).

## Dependencies

- [ ] No new dependencies added
- [x] New dependencies added (list below)
- [ ] Dependencies updated (list below)

- `github.com/redis/go-redis/v9`: v9.18.0 — Redis/Dragonfly client for distributed `ActiveQueueStore`
- `github.com/dgryski/go-rendezvous`: v0.0.0 — transitive dependency of go-redis
- `go.uber.org/atomic`: v1.11.0 — transitive dependency of go-redis

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] All method names, comments, and documentation are in English
- [ ] OpenAPI specification updated (if API changes were made)
- [x] Logging added for audit purposes (if applicable)

## Additional Notes

- The `replay-api` side (WebSocket consumer for `QueueStatusUpdated` events) is **out of scope** for this PR. A separate issue has been created: `replay-api-queue-status-websocket.issue.md`.
- The pre-existing test failure in `TestSendNotificationUseCase_Execute/fail_during_do_not_disturb_time` is unrelated to this PR (missing `IsAvailable` mock setup).
- Dragonfly is a Redis-compatible in-memory store; the implementation works with both vanilla Redis and Dragonfly without code changes.