### PR TITLE
feat(kafka): enhance Kafka configuration and security documentation

### DIFF
--- a/.docs/KAFKA_SECURITY.md
+++ b/.docs/KAFKA_SECURITY.md
@@ -1,0 +1,297 @@
+# Kafka Security — Matchmaking Cluster
+
+Configuration guide for **TLS**, **authentication (SASL)**, and **authorization (ACLs)** on the matchmaking Kafka cluster managed by **Strimzi**.
+
+## Bootstrap Endpoints
+
+| Listener | Protocol | Port | Use case |
+|----------|----------|------|----------|
+| **plain** | `PLAINTEXT` | `9092` | Development only (Docker Compose). No TLS, no auth. |
+| **tls** | `SSL` | `9093` | TLS-encrypted, no SASL. Used when mTLS alone is sufficient. |
+| **sasl-tls** | `SASL_SSL` | `9094` | TLS + SCRAM-SHA-512 auth. **Recommended for production.** |
+
+### Strimzi Bootstrap Addresses
+
+```
+# Internal (same namespace)
+matchmaking-kafka-bootstrap:9092   # plain
+matchmaking-kafka-bootstrap:9093   # tls
+matchmaking-kafka-bootstrap:9094   # sasl-tls
+
+# External (via Ingress/LoadBalancer — configure in Kafka CR listeners)
+matchmaking-kafka-0.example.com:9094
+```
+
+## Security Protocols
+
+The `KAFKA_SECURITY_PROTOCOL` environment variable controls which protocol the client uses:
+
+| Value | TLS | SASL | Description |
+|-------|-----|------|-------------|
+| `PLAINTEXT` | No | No | Development/Docker Compose only |
+| `SSL` | Yes | No | TLS encryption, optional mTLS client certs |
+| `SASL_PLAINTEXT` | No | Yes | SASL over plaintext — **not recommended** |
+| `SASL_SSL` | Yes | Yes | SASL + TLS — **recommended for production** |
+
+## Environment Variables
+
+```bash
+# Protocol & SASL
+KAFKA_SECURITY_PROTOCOL=SASL_SSL
+KAFKA_SASL_MECHANISM=SCRAM-SHA-512
+KAFKA_SASL_USERNAME=matchmaking-commands-consumer
+KAFKA_SASL_PASSWORD=<from KafkaUser Secret>
+
+# TLS certificates
+KAFKA_TLS_CA_CERT_PATH=/etc/kafka/certs/ca.crt
+KAFKA_TLS_CERT_PATH=/etc/kafka/certs/user.crt
+KAFKA_TLS_KEY_PATH=/etc/kafka/certs/user.key
+KAFKA_TLS_SKIP_VERIFY=false
+```
+
+## KafkaUser Resources
+
+Strimzi KafkaUser CRDs manage credentials and ACLs. Manifests are in `deploy/strimzi/`.
+
+### matchmaking-commands-consumer
+
+**Used by:** `matchmaking-worker` (PlayerQueuedConsumer)
+
+| Resource | Type | Operations |
+|----------|------|------------|
+| Topic `matchmaking.commands` | literal | Read, Describe |
+| Group `match-making-api-commands` | literal | Read |
+
+```bash
+kubectl apply -f deploy/strimzi/kafka-user-matchmaking-commands-consumer.yaml
+```
+
+### matchmaking-producer
+
+**Used by:** `match-making-api` (REST API) and `matchmaking-worker` (QueueStatusTicker)
+
+| Resource | Type | Operations |
+|----------|------|------------|
+| Topics `matchmaking.*` | prefix | Write, Describe, Create |
+| Topic `websocket.broadcasts` | literal | Write, Describe |
+
+```bash
+kubectl apply -f deploy/strimzi/kafka-user-matchmaking-producer.yaml
+```
+
+### matchmaking-match-results-consumer
+
+**Used by:** `match-making-api` (REST API — MatchResultConsumer)
+
+| Resource | Type | Operations |
+|----------|------|------------|
+| Topic `matchmaking.matches.results` | literal | Read, Describe |
+| Group `match-making-group` | literal | Read |
+
+```bash
+kubectl apply -f deploy/strimzi/kafka-user-matchmaking-match-results-consumer.yaml
+```
+
+## Extracting Credentials from Strimzi Secrets
+
+When a `KafkaUser` is created, Strimzi generates a Secret with the same name containing the password (for SCRAM) or certificates (for mTLS).
+
+### SCRAM password
+
+```bash
+# Get password for a KafkaUser
+kubectl get secret matchmaking-commands-consumer \
+  -o jsonpath='{.data.password}' | base64 -d
+
+# Get SASL/JAAS config string
+kubectl get secret matchmaking-commands-consumer \
+  -o jsonpath='{.data.sasl\.jaas\.config}' | base64 -d
+```
+
+### Cluster CA certificate
+
+```bash
+# The cluster CA cert is in a Secret named <cluster>-cluster-ca-cert
+kubectl get secret matchmaking-cluster-ca-cert \
+  -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
+```
+
+### Client certificates (if mTLS)
+
+```bash
+kubectl get secret matchmaking-commands-consumer \
+  -o jsonpath='{.data.user\.crt}' | base64 -d > user.crt
+
+kubectl get secret matchmaking-commands-consumer \
+  -o jsonpath='{.data.user\.key}' | base64 -d > user.key
+```
+
+## Mounting Certs in Kubernetes Pods
+
+Use Kubernetes volume mounts to make certs available to the application pods:
+
+```yaml
+# In Deployment spec
+volumes:
+  - name: kafka-ca-cert
+    secret:
+      secretName: matchmaking-cluster-ca-cert
+      items:
+        - key: ca.crt
+          path: ca.crt
+  - name: kafka-user-certs
+    secret:
+      secretName: matchmaking-commands-consumer
+      items:
+        - key: user.crt
+          path: user.crt
+        - key: user.key
+          path: user.key
+
+containers:
+  - name: matchmaking-worker
+    volumeMounts:
+      - name: kafka-ca-cert
+        mountPath: /etc/kafka/certs
+        readOnly: true
+      - name: kafka-user-certs
+        mountPath: /etc/kafka/certs
+        readOnly: true
+    env:
+      - name: KAFKA_SECURITY_PROTOCOL
+        value: "SASL_SSL"
+      - name: KAFKA_SASL_MECHANISM
+        value: "SCRAM-SHA-512"
+      - name: KAFKA_SASL_USERNAME
+        value: "matchmaking-commands-consumer"
+      - name: KAFKA_SASL_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: matchmaking-commands-consumer
+            key: password
+      - name: KAFKA_TLS_CA_CERT_PATH
+        value: "/etc/kafka/certs/ca.crt"
+```
+
+## Certificate Rotation Runbook
+
+### Strimzi auto-rotation (cluster CA)
+
+Strimzi renews the cluster CA automatically before expiry (default: 365 days, renewal 30 days before). To force rotation:
+
+```bash
+# Annotate the cluster CA Secret to trigger renewal
+kubectl annotate secret matchmaking-cluster-ca-cert \
+  strimzi.io/force-renew=true
+
+# Monitor rollout
+kubectl get pods -l strimzi.io/cluster=matchmaking -w
+```
+
+After rotation:
+1. **Pods using volume mounts**: Kubernetes auto-updates the Secret volume (may take up to 60s).
+2. **Pods using env vars**: Restart required to pick up new certificates.
+3. **External clients**: Manually extract and distribute the new `ca.crt`.
+
+### KafkaUser credential rotation
+
+To rotate a SCRAM user password:
+
+```bash
+# Delete and recreate the KafkaUser to regenerate password
+kubectl delete kafkauser matchmaking-commands-consumer
+kubectl apply -f deploy/strimzi/kafka-user-matchmaking-commands-consumer.yaml
+
+# Wait for the Secret to be recreated
+kubectl get secret matchmaking-commands-consumer -w
+
+# Extract the new password
+kubectl get secret matchmaking-commands-consumer \
+  -o jsonpath='{.data.password}' | base64 -d
+```
+
+For zero-downtime rotation:
+1. Create a **new** KafkaUser with a different name (e.g., `matchmaking-commands-consumer-v2`).
+2. Update the application deployment to use the new credentials.
+3. Verify connectivity.
+4. Delete the old KafkaUser.
+
+### mTLS client certificate rotation
+
+Strimzi renews user certificates automatically. To force:
+
+```bash
+kubectl annotate secret matchmaking-commands-consumer \
+  strimzi.io/force-renew=true
+```
+
+## Access Troubleshooting
+
+### Common errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `TOPIC_AUTHORIZATION_FAILED` | Missing ACL for topic | Add topic ACL to KafkaUser |
+| `GROUP_AUTHORIZATION_FAILED` | Missing ACL for consumer group | Add group ACL to KafkaUser; verify `groupID` matches ACL |
+| `SASL authentication failed` | Wrong username/password | Re-extract password from KafkaUser Secret |
+| `x509: certificate signed by unknown authority` | Missing or wrong CA cert | Mount cluster CA cert; set `KAFKA_TLS_CA_CERT_PATH` |
+| `tls: bad certificate` | Client cert rejected by broker | Verify KafkaUser cert is not expired; force-renew |
+| `i/o timeout` on `9093`/`9094` | Firewall or wrong bootstrap | Check network policy; verify bootstrap address |
+
+### Diagnostic commands
+
+```bash
+# Test TLS connectivity
+openssl s_client -connect matchmaking-kafka-bootstrap:9093 \
+  -CAfile ca.crt -showcerts
+
+# Test SASL + TLS with kafkacat (kcat)
+kcat -b matchmaking-kafka-bootstrap:9094 \
+  -X security.protocol=SASL_SSL \
+  -X sasl.mechanism=SCRAM-SHA-512 \
+  -X sasl.username=matchmaking-commands-consumer \
+  -X sasl.password=$(kubectl get secret matchmaking-commands-consumer -o jsonpath='{.data.password}' | base64 -d) \
+  -X ssl.ca.location=ca.crt \
+  -L
+
+# List ACLs for a user
+kubectl exec matchmaking-kafka-0 -- bin/kafka-acls.sh \
+  --bootstrap-server localhost:9092 \
+  --list --principal User:matchmaking-commands-consumer
+
+# Describe consumer group
+kubectl exec matchmaking-kafka-0 -- bin/kafka-consumer-groups.sh \
+  --bootstrap-server localhost:9092 \
+  --describe --group match-making-api-commands
+```
+
+### Verify KafkaUser status
+
+```bash
+# Check if KafkaUser is ready
+kubectl get kafkauser matchmaking-commands-consumer -o yaml
+
+# Look for conditions
+kubectl get kafkauser matchmaking-commands-consumer \
+  -o jsonpath='{.status.conditions[*].type}'
+# Expected: Ready
+```
+
+## Development Setup
+
+For **local development** (Docker Compose), Kafka runs without security:
+
+```bash
+KAFKA_BOOTSTRAP_SERVERS=localhost:29092,localhost:39092
+KAFKA_SECURITY_PROTOCOL=PLAINTEXT
+```
+
+No TLS, no SASL, no ACLs. This is intentional for developer experience.
+
+## References
+
+- [Strimzi KafkaUser Documentation](https://strimzi.io/docs/operators/latest/configuring.html#type-KafkaUser-reference)
+- [Strimzi TLS / Authentication](https://strimzi.io/docs/operators/latest/configuring.html#assembly-securing-access-str)
+- [Strimzi Certificate Renewal](https://strimzi.io/docs/operators/latest/deploying.html#proc-renewing-ca-certs-manually-str)
+- Epic §10 — Consumer Group Patterns
+- Migration Phase 1 — Configure security (TLS, authentication)

--- a/.env.example
+++ b/.env.example
@@ -24,10 +24,38 @@ MONGO_DB_NAME=match-making
 # ============================================
 # Kafka Configuration
 # ============================================
-KAFKA_BOOTSTRAP=kafka-1:29092,kafka-2:39092
+# Broker addresses (comma-separated)
+# Development: localhost:29092,localhost:39092
+# Docker: kafka-1:29092,kafka-2:39092
+# Strimzi TLS: matchmaking-kafka-bootstrap:9093
+KAFKA_BOOTSTRAP_SERVERS=kafka-1:29092,kafka-2:39092
 KAFKA_VERSION=3.6.0
 KAFKA_CONSUMER_GROUP_ID=match-making-group
 KAFKA_PARTITION_ASSIGNMENT_STRATEGY=range
+
+# ============================================
+# Kafka Security Configuration
+# ============================================
+# Security protocol: PLAINTEXT | SSL | SASL_PLAINTEXT | SASL_SSL
+# Development: PLAINTEXT (default, no auth)
+# Production Strimzi: SASL_SSL
+KAFKA_SECURITY_PROTOCOL=PLAINTEXT
+
+# SASL authentication (only when SASL_PLAINTEXT or SASL_SSL)
+# Supported mechanisms: SCRAM-SHA-256, SCRAM-SHA-512
+# Strimzi: credentials are managed via KafkaUser Secret
+KAFKA_SASL_MECHANISM=
+KAFKA_SASL_USERNAME=
+KAFKA_SASL_PASSWORD=
+
+# TLS certificates (only when SSL or SASL_SSL)
+# CA cert: path to Strimzi cluster CA (ca.crt from <cluster>-cluster-ca-cert Secret)
+# Client cert/key: for mTLS (user.crt/user.key from KafkaUser Secret)
+KAFKA_TLS_CA_CERT_PATH=
+KAFKA_TLS_CERT_PATH=
+KAFKA_TLS_KEY_PATH=
+# Skip TLS verification (dev/test only, never in production)
+KAFKA_TLS_SKIP_VERIFY=false
 
 # ============================================
 # Redis / Dragonfly Configuration

--- a/deploy/strimzi/kafka-user-matchmaking-commands-consumer.yaml
+++ b/deploy/strimzi/kafka-user-matchmaking-commands-consumer.yaml
@@ -1,0 +1,41 @@
+# KafkaUser for the matchmaking-commands consumer group.
+# Used by the matchmaking-worker to consume PlayerQueued events.
+#
+# Auth: SCRAM-SHA-512 (Strimzi manages credentials via Secret)
+# ACLs: Read on matchmaking.commands topic + consumer group
+#
+# Prerequisites:
+#   - Strimzi Operator installed
+#   - Kafka cluster "matchmaking" deployed with authentication.type: scram-sha-512
+#
+# Apply: kubectl apply -f kafka-user-matchmaking-commands-consumer.yaml
+# Secret: kubectl get secret matchmaking-commands-consumer -o jsonpath='{.data.password}' | base64 -d
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: matchmaking-commands-consumer
+  labels:
+    strimzi.io/cluster: matchmaking
+spec:
+  authentication:
+    type: scram-sha-512
+  authorization:
+    type: simple
+    acls:
+      # Read from matchmaking.commands topic
+      - resource:
+          type: topic
+          name: matchmaking.commands
+          patternType: literal
+        operations:
+          - Read
+          - Describe
+        host: "*"
+      # Consumer group access
+      - resource:
+          type: group
+          name: match-making-api-commands
+          patternType: literal
+        operations:
+          - Read
+        host: "*"

--- a/deploy/strimzi/kafka-user-matchmaking-match-results-consumer.yaml
+++ b/deploy/strimzi/kafka-user-matchmaking-match-results-consumer.yaml
@@ -1,0 +1,41 @@
+# KafkaUser for the match results consumer.
+# Used by the REST API to consume match result events.
+#
+# Auth: SCRAM-SHA-512 (Strimzi manages credentials via Secret)
+# ACLs: Read on matchmaking.matches.results topic + consumer group
+#
+# Prerequisites:
+#   - Strimzi Operator installed
+#   - Kafka cluster "matchmaking" deployed with authentication.type: scram-sha-512
+#
+# Apply: kubectl apply -f kafka-user-matchmaking-match-results-consumer.yaml
+# Secret: kubectl get secret matchmaking-match-results-consumer -o jsonpath='{.data.password}' | base64 -d
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: matchmaking-match-results-consumer
+  labels:
+    strimzi.io/cluster: matchmaking
+spec:
+  authentication:
+    type: scram-sha-512
+  authorization:
+    type: simple
+    acls:
+      # Read from match results topic
+      - resource:
+          type: topic
+          name: matchmaking.matches.results
+          patternType: literal
+        operations:
+          - Read
+          - Describe
+        host: "*"
+      # Consumer group access
+      - resource:
+          type: group
+          name: match-making-group
+          patternType: literal
+        operations:
+          - Read
+        host: "*"

--- a/deploy/strimzi/kafka-user-matchmaking-producer.yaml
+++ b/deploy/strimzi/kafka-user-matchmaking-producer.yaml
@@ -1,0 +1,43 @@
+# KafkaUser for the matchmaking event producer.
+# Used by both the REST API and matchmaking-worker to publish events.
+#
+# Auth: SCRAM-SHA-512 (Strimzi manages credentials via Secret)
+# ACLs: Write on all matchmaking topics + websocket.broadcasts
+#
+# Prerequisites:
+#   - Strimzi Operator installed
+#   - Kafka cluster "matchmaking" deployed with authentication.type: scram-sha-512
+#
+# Apply: kubectl apply -f kafka-user-matchmaking-producer.yaml
+# Secret: kubectl get secret matchmaking-producer -o jsonpath='{.data.password}' | base64 -d
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: matchmaking-producer
+  labels:
+    strimzi.io/cluster: matchmaking
+spec:
+  authentication:
+    type: scram-sha-512
+  authorization:
+    type: simple
+    acls:
+      # Write to matchmaking event topics
+      - resource:
+          type: topic
+          name: matchmaking.
+          patternType: prefix
+        operations:
+          - Write
+          - Describe
+          - Create
+        host: "*"
+      # Write to websocket.broadcasts (QueueStatusUpdated events)
+      - resource:
+          type: topic
+          name: websocket.broadcasts
+          patternType: literal
+        operations:
+          - Write
+          - Describe
+        host: "*"

--- a/pkg/infra/kafka/client.go
+++ b/pkg/infra/kafka/client.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -11,16 +12,27 @@ import (
 	"time"
 
 	"github.com/segmentio/kafka-go"
+	"github.com/segmentio/kafka-go/sasl"
 	"github.com/segmentio/kafka-go/sasl/scram"
 )
 
-// Config holds Kafka client configuration
+// Config holds Kafka client configuration.
+//
+// Security protocols:
+//   - PLAINTEXT: no encryption, no auth (development only)
+//   - SSL: TLS encryption, optional mTLS client certs
+//   - SASL_PLAINTEXT: SASL auth over plaintext (not recommended)
+//   - SASL_SSL: SASL auth over TLS (recommended for production)
 type Config struct {
 	BootstrapServers string
-	SecurityProtocol string
-	SASLMechanism    string
+	SecurityProtocol string // PLAINTEXT | SSL | SASL_PLAINTEXT | SASL_SSL
+	SASLMechanism    string // SCRAM-SHA-256 | SCRAM-SHA-512
 	SASLUsername     string
 	SASLPassword     string
+	TLSCACertPath    string // Path to CA certificate (PEM) for broker verification
+	TLSCertPath      string // Path to client certificate (PEM) for mTLS
+	TLSKeyPath       string // Path to client private key (PEM) for mTLS
+	TLSSkipVerify    bool   // Skip server certificate verification (dev/test only)
 	Region           string
 }
 
@@ -31,7 +43,7 @@ type Client struct {
 	writers map[string]*kafka.Writer
 }
 
-// NewConfigFromEnv creates Config from environment variables
+// NewConfigFromEnv creates Config from environment variables.
 func NewConfigFromEnv() *Config {
 	return &Config{
 		BootstrapServers: getEnv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092"),
@@ -39,38 +51,107 @@ func NewConfigFromEnv() *Config {
 		SASLMechanism:    getEnv("KAFKA_SASL_MECHANISM", ""),
 		SASLUsername:     getEnv("KAFKA_SASL_USERNAME", ""),
 		SASLPassword:     getEnv("KAFKA_SASL_PASSWORD", ""),
+		TLSCACertPath:    getEnv("KAFKA_TLS_CA_CERT_PATH", ""),
+		TLSCertPath:      getEnv("KAFKA_TLS_CERT_PATH", ""),
+		TLSKeyPath:       getEnv("KAFKA_TLS_KEY_PATH", ""),
+		TLSSkipVerify:    getEnv("KAFKA_TLS_SKIP_VERIFY", "false") == "true",
 		Region:           getEnv("REGION", "local"),
 	}
 }
 
-// NewClient creates a new Kafka client
+// NewClient creates a new Kafka client with the given configuration.
+// Supports PLAINTEXT, SSL, SASL_PLAINTEXT, and SASL_SSL security protocols.
 func NewClient(config *Config) (*Client, error) {
 	dialer := &kafka.Dialer{
 		Timeout:   10 * time.Second,
 		DualStack: true,
 	}
 
-	// Configure SASL authentication if enabled
-	if config.SASLMechanism == "SCRAM-SHA-512" {
-		mechanism, err := scram.Mechanism(scram.SHA512, config.SASLUsername, config.SASLPassword)
+	// Configure SASL authentication if mechanism is set
+	if config.SASLMechanism != "" {
+		mechanism, err := buildSASLMechanism(config)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create SCRAM mechanism: %w", err)
+			return nil, err
 		}
 		dialer.SASLMechanism = mechanism
 	}
 
-	// Configure TLS if using SASL_SSL
-	if config.SecurityProtocol == "SASL_SSL" {
-		dialer.TLS = &tls.Config{
-			MinVersion: tls.VersionTLS12,
+	// Configure TLS for SSL or SASL_SSL protocols
+	if config.SecurityProtocol == "SSL" || config.SecurityProtocol == "SASL_SSL" {
+		tlsConfig, err := buildTLSConfig(config)
+		if err != nil {
+			return nil, err
 		}
+		dialer.TLS = tlsConfig
 	}
+
+	slog.Info("Kafka client configured",
+		"bootstrap_servers", config.BootstrapServers,
+		"security_protocol", config.SecurityProtocol,
+		"sasl_mechanism", config.SASLMechanism,
+		"tls_ca_cert", config.TLSCACertPath != "",
+		"tls_client_cert", config.TLSCertPath != "",
+		"region", config.Region)
 
 	return &Client{
 		config:  config,
 		dialer:  dialer,
 		writers: make(map[string]*kafka.Writer),
 	}, nil
+}
+
+// buildSASLMechanism creates the SASL mechanism from config.
+func buildSASLMechanism(config *Config) (sasl.Mechanism, error) {
+	switch config.SASLMechanism {
+	case "SCRAM-SHA-512":
+		mechanism, err := scram.Mechanism(scram.SHA512, config.SASLUsername, config.SASLPassword)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create SCRAM-SHA-512 mechanism: %w", err)
+		}
+		return mechanism, nil
+	case "SCRAM-SHA-256":
+		mechanism, err := scram.Mechanism(scram.SHA256, config.SASLUsername, config.SASLPassword)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create SCRAM-SHA-256 mechanism: %w", err)
+		}
+		return mechanism, nil
+	default:
+		return nil, fmt.Errorf("unsupported SASL mechanism: %s (supported: SCRAM-SHA-256, SCRAM-SHA-512)", config.SASLMechanism)
+	}
+}
+
+// buildTLSConfig creates TLS configuration from config.
+// Supports custom CA certificate, client certificates (mTLS), and skip-verify for dev.
+func buildTLSConfig(config *Config) (*tls.Config, error) {
+	tlsConfig := &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: config.TLSSkipVerify,
+	}
+
+	// Load custom CA certificate for broker verification
+	if config.TLSCACertPath != "" {
+		caCert, err := os.ReadFile(config.TLSCACertPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CA certificate from %s: %w", config.TLSCACertPath, err)
+		}
+		caCertPool := x509.NewCertPool()
+		if !caCertPool.AppendCertsFromPEM(caCert) {
+			return nil, fmt.Errorf("failed to parse CA certificate from %s", config.TLSCACertPath)
+		}
+		tlsConfig.RootCAs = caCertPool
+	}
+
+	// Load client certificate and key for mTLS
+	if config.TLSCertPath != "" && config.TLSKeyPath != "" {
+		cert, err := tls.LoadX509KeyPair(config.TLSCertPath, config.TLSKeyPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load client certificate/key (%s, %s): %w",
+				config.TLSCertPath, config.TLSKeyPath, err)
+		}
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	}
+
+	return tlsConfig, nil
 }
 
 // GetWriter returns a cached writer for the given topic


### PR DESCRIPTION
## Summary

This PR implements **Kafka security configuration** for the matchmaking cluster: TLS encryption, SASL-SCRAM authentication, Strimzi KafkaUser ACLs for consumer/producer roles, and a comprehensive security runbook covering bootstrap endpoints, credential extraction, certificate rotation, and access troubleshooting.

## Key Features Added

### Kafka Client Security (`pkg/infra/kafka/client.go`)

- **Full security protocol support**: Added support for all four Kafka security protocols — `PLAINTEXT`, `SSL`, `SASL_PLAINTEXT`, and `SASL_SSL`
- **SCRAM-SHA-256 support**: Extended SASL authentication to support both `SCRAM-SHA-256` and `SCRAM-SHA-512` mechanisms
- **Custom CA certificate**: New `KAFKA_TLS_CA_CERT_PATH` env var to load Strimzi cluster CA for broker verification
- **mTLS client certificates**: New `KAFKA_TLS_CERT_PATH` and `KAFKA_TLS_KEY_PATH` env vars for mutual TLS authentication
- **TLS skip-verify**: `KAFKA_TLS_SKIP_VERIFY` flag for dev/test environments
- **Structured helpers**: Extracted `buildSASLMechanism()` and `buildTLSConfig()` for clean separation of concerns

### Strimzi KafkaUser & ACLs (`deploy/strimzi/`)

- **matchmaking-commands-consumer**: Read ACL on `matchmaking.commands` topic + `match-making-api-commands` consumer group (used by matchmaking-worker)
- **matchmaking-producer**: Write ACL on `matchmaking.*` prefix topics + `websocket.broadcasts` (used by REST API and worker)
- **matchmaking-match-results-consumer**: Read ACL on `matchmaking.matches.results` + `match-making-group` consumer group (used by REST API)

### Infrastructure Improvements

- **Environment variables**: `.env.example` updated with all Kafka security env vars, fully documented with comments for dev vs. production values
- **Security runbook**: `.docs/KAFKA_SECURITY.md` — comprehensive documentation covering bootstrap endpoints, protocols, credential extraction, Kubernetes volume mounts, certificate rotation, and troubleshooting

## Architecture Highlights

**Design Patterns:**
- Ports & Adapters — TLS/SASL configuration is encapsulated within the Kafka infrastructure layer, transparent to domain code
- Configuration-driven security — all security settings controlled via environment variables, no code changes needed to switch between PLAINTEXT (dev) and SASL_SSL (prod)

**Key Components:**
- `buildSASLMechanism()` — factory for SCRAM-SHA-256/512 mechanisms with clear error messages for unsupported types
- `buildTLSConfig()` — composable TLS builder supporting CA certs, client certs (mTLS), and skip-verify independently

**Security & Best Practices:**
- TLS 1.2 minimum enforced
- Principle of least privilege: each KafkaUser has only the ACLs needed for its specific role
- Prefix-based ACL for producer (`matchmaking.*`) allows topic creation without manifest updates
- `InsecureSkipVerify` defaults to `false` and is documented as dev-only
- Runbook includes zero-downtime credential rotation procedure

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update

## Related Issue

Closes #18

## Test Plan

- [x] Build project: `go build ./...`
- [x] Run unit tests: `go test ./...`
- [ ] Run integration tests (if applicable)
- [ ] Manual testing performed
- [x] All API endpoints tested
- [x] Error handling verified
- [x] Edge cases tested
- [ ] Performance tested (if applicable)
- [x] Security checks performed
- [x] No sensitive data in commits

### Test Steps

1. Verify build compiles: `go build ./...` — ensures new imports (`crypto/x509`, `sasl`) resolve correctly
2. Verify all existing tests pass: `go test ./...` — confirms no regressions from Config struct changes
3. Verify PLAINTEXT mode (default): start with `KAFKA_SECURITY_PROTOCOL=PLAINTEXT` — client should connect without TLS/SASL (existing behavior preserved)
4. Verify SASL_SSL mode: set `KAFKA_SECURITY_PROTOCOL=SASL_SSL`, `KAFKA_SASL_MECHANISM=SCRAM-SHA-512`, provide credentials and CA cert — client should connect with TLS + SCRAM auth
5. Verify error handling: set `KAFKA_SASL_MECHANISM=UNSUPPORTED` — should return clear error message
6. Apply KafkaUser manifests to a Strimzi cluster and verify ACLs with `kafka-acls.sh`

## Files Changed

- 6 files changed
- 545 insertions(+)
- 14 deletions(-)

## Database Migration

N/A

## Dependencies

- [x] No new dependencies added

> The `crypto/x509` and `github.com/segmentio/kafka-go/sasl` packages were already transitive dependencies; no new entries in `go.mod`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] All method names, comments, and documentation are in English
- [ ] OpenAPI specification updated (if API changes were made)
- [x] Logging added for audit purposes (if applicable)

## Additional Notes

- The existing `.env` uses `KAFKA_BOOTSTRAP` while the Kafka client reads `KAFKA_BOOTSTRAP_SERVERS`. Both coexist — the legacy `KafkaConfig` struct reads `KAFKA_BOOTSTRAP` but is not actively consumed. The `.env.example` now documents `KAFKA_BOOTSTRAP_SERVERS` as the canonical variable.
- KafkaUser manifests in `deploy/strimzi/` are ready to apply but require a running Strimzi Operator and the `matchmaking` Kafka cluster (issue #15).
- The security runbook (`.docs/KAFKA_SECURITY.md`) includes diagnostic commands using `openssl`, `kcat`, and Kafka CLI tools for troubleshooting connectivity and ACL issues.