### PR TITLE
docs: add ADR-002 for notifications topic decision and update EVENT_SCHEMAS.md

### DIFF
--- a/.docs/ADR-002-notifications-topic-decision.md
+++ b/.docs/ADR-002-notifications-topic-decision.md
@@ -1,0 +1,115 @@
+# ADR-002: Notifications Topic — Decision Record
+
+| Field       | Value |
+|-------------|-------|
+| **Status**  | Accepted |
+| **Date**    | 2026-02-17 |
+| **Deciders** | Match-Making-API team |
+| **Related** | Epic §10 Kafka Topic Architecture, Issue #20 (this story), #22 (QueueStatusUpdated), #26 (MatchReady), #27 (MatchStarted) |
+
+## Context
+
+The epic §10 references a **`matchmaking.notifications`** topic for user-facing real-time events (queue_status, match_ready). The platform already has a **`websocket.broadcasts`** topic that serves as the delivery channel for WebSocket messages — consumed by **replay-api**'s WebSocket hub, which delivers events directly to player connections.
+
+Currently, **QueueStatusUpdated** events (#22) are produced directly to `websocket.broadcasts` by the `QueueStatusTicker` worker. Future events like **MatchReady** (#26) and **MatchStarted** (#27) will also target specific players in real-time.
+
+We need to decide whether to create a dedicated `matchmaking.notifications` topic or continue routing through existing topics.
+
+## Decision
+
+**We will NOT create a `matchmaking.notifications` topic.** Real-time notification events are produced directly to **`websocket.broadcasts`**, which is already consumed by the WebSocket hub for player delivery.
+
+## Rationale
+
+### Why `websocket.broadcasts` is sufficient
+
+1. **Direct delivery path.** All current notification events (`QueueStatusUpdated`) and planned ones (`MatchReady`, `MatchStarted`) are WebSocket-bound. The `websocket.broadcasts` topic is already consumed by `replay-api`'s WebSocket hub, which delivers events to player connections. Adding an intermediate `matchmaking.notifications` topic would require a **consumer to re-route** events to `websocket.broadcasts`, adding latency without functional benefit.
+
+2. **`WebSocketBroadcastEvent` already supports targeted delivery.** The existing payload struct includes `TargetIDs []uuid.UUID` for player-specific delivery and `LobbyID` for lobby-scoped broadcasts. This covers all notification use cases:
+   - `QueueStatusUpdated` → `TargetIDs: [playerID]`
+   - `MatchReady` → `TargetIDs: [player1, player2, ...]` or `LobbyID: lobbyID`
+   - `MatchStarted` → `LobbyID: lobbyID`
+
+3. **Operational simplicity.** One fewer topic to create, monitor, tune partitions/retention, and secure with ACLs. At our scale (2 services, <5 notification event types), the overhead is not justified.
+
+4. **Separation already exists at the event type level.** Each event carries a `type` field (`QUEUE_STATUS_UPDATED`, `MATCH_READY`, etc.) that consumers use for routing. Domain-level separation is achieved through event types, not topic segregation.
+
+### When to reconsider
+
+Introduce `matchmaking.notifications` if any of the following become true:
+
+- **Non-WebSocket notification channels** are needed (email, push notifications, SMS) — a dedicated topic allows multiple consumers with different delivery strategies
+- **Rate limiting or backpressure** is needed specifically for notifications without affecting other `websocket.broadcasts` traffic
+- **>3 independent services** consume notification events with different SLAs
+- **Audit or compliance** requires a persistent log of all user notifications separate from WebSocket delivery
+
+### Migration path (if needed later)
+
+1. Create `matchmaking.notifications` topic with appropriate partitions/retention
+2. Update producers (`QueueStatusTicker`, future MatchReady/MatchStarted producers) to publish to `matchmaking.notifications` instead of `websocket.broadcasts`
+3. Create a lightweight consumer that reads from `matchmaking.notifications` and republishes to `websocket.broadcasts` (or have the WebSocket hub consume directly from `matchmaking.notifications`)
+4. Add consumers for other channels (email service, push notification service)
+
+## Consequences
+
+### Positive
+
+- No additional topic to manage (partitions, retention, ACLs, monitoring)
+- Lower end-to-end latency (events go directly to WebSocket delivery)
+- Simpler producer code (single publish call)
+- Existing `QueueStatusTicker` and planned producers need no changes
+
+### Negative
+
+- All notification events share `websocket.broadcasts` with other broadcast events (lobby updates, etc.)
+- If non-WebSocket channels are needed, producers must be updated to publish to a new topic
+- No separate retention/partitioning for notification events vs. other broadcasts
+
+### Neutral
+
+- Event types provide logical separation within the shared topic
+- ACLs for `websocket.broadcasts` are already configured in the `matchmaking-producer` KafkaUser
+
+## Notification Event Routing (Current Architecture)
+
+```
+match-making-api                          replay-api
+┌──────────────────────┐                  ┌──────────────────────┐
+│ QueueStatusTicker    │                  │ WebSocket Hub        │
+│   (worker)           │──publish──┐      │                      │
+│                      │           │      │ WebSocketBroadcast   │
+│ MatchReady producer  │──publish──┼─────►│   Consumer           │──► Player WS
+│   (future #26)       │           │      │                      │
+│                      │           │      │ Routes by event type │
+│ MatchStarted producer│──publish──┘      │ + TargetIDs/LobbyID  │
+│   (future #27)       │                  │                      │
+└──────────────────────┘                  └──────────────────────┘
+            │                                        │
+            └─── websocket.broadcasts topic ─────────┘
+```
+
+## Alternatives Considered
+
+### Create `matchmaking.notifications` + consumer to route to `websocket.broadcasts`
+
+- **Pros**: Clean domain separation; ready for multi-channel delivery; separate retention/partitioning
+- **Cons**: Extra hop adds ~5-15ms latency; extra consumer to deploy/monitor; no current need for multi-channel
+- **Verdict**: Overkill for current architecture; easy to add later if needed
+
+### Create `matchmaking.notifications` and have WebSocket hub consume it directly
+
+- **Pros**: Domain topic with direct consumption; no intermediate routing
+- **Cons**: WebSocket hub already consumes `websocket.broadcasts` and `matchmaking.lobby.events`; adding a third topic increases consumer complexity; breaks existing convention
+- **Verdict**: Cleaner than option 1 but still adds unnecessary topic at current scale
+
+### Use `matchmaking.events` (generic domain events topic)
+
+- **Pros**: Single topic for all matchmaking domain events
+- **Cons**: Mixes domain events (MatchCreated, RatingsUpdated) with user-facing notifications (QueueStatus, MatchReady); different retention and consumer needs; high-throughput events would drown low-latency notifications
+- **Verdict**: Wrong abstraction level; domain events and notifications serve different purposes
+
+## Related Documents
+
+- [ADR-001: Schema Registry Decision](ADR-001-schema-registry-decision.md)
+- [EVENT_SCHEMAS.md](EVENT_SCHEMAS.md) — schema catalog, topic mapping
+- [KAFKA_SECURITY.md](KAFKA_SECURITY.md) — KafkaUser ACLs for `websocket.broadcasts`

--- a/.docs/EVENT_SCHEMAS.md
+++ b/.docs/EVENT_SCHEMAS.md
@@ -86,7 +86,29 @@ Placeholder for producer use (2501-003). Payload includes `match_id`, `player_id
 
 Placeholder for the epic. Payload includes `deltas[]` of MMR per player.
 
+### QueueStatusUpdated (match-making-api → replay-api, via `websocket.broadcasts`)
+
+Emitted every 5s by the `worker-queue-status` for each active queue entry. Delivered to the player's WebSocket connection via `replay-api`.
+
+**Payload** (`QueueStatusPayload` — JSON, not Protobuf):
+- `player_id`, `game_id`, `region` (required)
+- `position` (int): current queue position
+- `estimated_wait_ms` (int64): estimated remaining wait in milliseconds
+- `total_in_queue` (int): total players in the queue
+- `event_type`: `"QUEUE_STATUS_UPDATED"`
+- `timestamp` (int64): Unix epoch ms
+
+### MatchReady (planned, #26)
+
+Placeholder. Will notify players when a lobby is full and the match is ready to start. Published to `websocket.broadcasts` with `TargetIDs` set to lobby player IDs.
+
+### MatchStarted (planned, #27)
+
+Placeholder. Will notify players when the match has officially started. Published to `websocket.broadcasts` with `LobbyID` set.
+
 ## Topic → Schema Mapping
+
+### Domain Events (Protobuf/CloudEvents)
 
 | Topic | Direction | Events | Proto Message | `dataschema_version` |
 |-------|-----------|--------|---------------|----------------------|
@@ -94,6 +116,26 @@ Placeholder for the epic. Payload includes `deltas[]` of MMR per player.
 | `matchmaking.matches.created` | match-making-api → replay-api | MatchCreated | `MatchCreatedPayload` | 1 |
 | `matchmaking.matches` | match-making-api → replay-api | MatchCompleted | `MatchCompletedPayload` | 1 |
 | (TBD) | match-making-api → replay-api | RatingsUpdated | `RatingsUpdatedPayload` | 1 |
+
+### Real-Time Notifications (JSON, via `websocket.broadcasts`)
+
+> **Decision**: We do NOT use a dedicated `matchmaking.notifications` topic. Notification events are published directly to `websocket.broadcasts` for WebSocket delivery. See [ADR-002](ADR-002-notifications-topic-decision.md).
+
+| Topic | Direction | Events | Payload Format | Delivery |
+|-------|-----------|--------|----------------|----------|
+| `websocket.broadcasts` | match-making-api → replay-api | QueueStatusUpdated | `QueueStatusPayload` (JSON) | `TargetIDs: [playerID]` |
+| `websocket.broadcasts` | match-making-api → replay-api | MatchReady (#26) | TBD | `TargetIDs: [playerIDs...]` or `LobbyID` |
+| `websocket.broadcasts` | match-making-api → replay-api | MatchStarted (#27) | TBD | `LobbyID` |
+| `websocket.broadcasts` | match-making-api → replay-api | LobbyUpdated, PlayerJoined, etc. | `WebSocketBroadcastEvent` (JSON) | `LobbyID` |
+
+### Other Topics
+
+| Topic | Direction | Events | Notes |
+|-------|-----------|--------|-------|
+| `matchmaking.queue.events` | match-making-api internal | QueueJoined, QueueLeft, Searching | Legacy queue events |
+| `matchmaking.lobby.events` | match-making-api → replay-api | LobbyCreated, LobbyUpdated, etc. | Lobby lifecycle events |
+| `matchmaking.player-status` | match-making-api → replay-api | Player status changes | Player online/offline |
+| `matchmaking.dlq` | match-making-api internal | Failed events | Dead letter queue |
 
 ---
 

--- a/deploy/strimzi/kafka-user-matchmaking-producer.yaml
+++ b/deploy/strimzi/kafka-user-matchmaking-producer.yaml
@@ -1,8 +1,8 @@
 # KafkaUser for the matchmaking event producer.
-# Used by both the REST API and matchmaking-worker to publish events.
+# Used by the REST API, consumer-matchmaking-commands, and worker-queue-status to publish events.
 #
 # Auth: SCRAM-SHA-512 (Strimzi manages credentials via Secret)
-# ACLs: Write on all matchmaking topics + websocket.broadcasts
+# ACLs: Write on all matchmaking topics + websocket.broadcasts (real-time notifications)
 #
 # Prerequisites:
 #   - Strimzi Operator installed
@@ -32,7 +32,8 @@ spec:
           - Describe
           - Create
         host: "*"
-      # Write to websocket.broadcasts (QueueStatusUpdated events)
+      # Write to websocket.broadcasts (real-time notifications: QueueStatusUpdated, MatchReady, MatchStarted)
+      # See ADR-002: notifications are routed via websocket.broadcasts, not a separate topic
       - resource:
           type: topic
           name: websocket.broadcasts

--- a/pkg/infra/kafka/events.go
+++ b/pkg/infra/kafka/events.go
@@ -41,6 +41,7 @@ const (
 	EventTypeMatchCompleted     = "MATCH_COMPLETED"
 	EventTypeMatchCancelled     = "MATCH_CANCELLED"
 	EventTypeQueueStatusUpdated = "QUEUE_STATUS_UPDATED"
+	EventTypeMatchReady         = "MATCH_READY"   // Planned (#26): lobby is full, match ready to start
 )
 
 // QueueStatusPayload is the payload for QUEUE_STATUS_UPDATED events.


### PR DESCRIPTION
Aqui está o texto do PR:

---

## Summary

This PR documents the **notifications topic decision** for the matchmaking platform. After evaluating three approaches (dedicated `matchmaking.notifications` topic, reuse of `matchmaking.events`, and the current `websocket.broadcasts` pattern), the decision is to **not create a dedicated notifications topic** — real-time notification events (`QueueStatusUpdated`, `MatchReady`, `MatchStarted`) are routed directly through `websocket.broadcasts`, which is already consumed by `replay-api`'s WebSocket hub for player delivery.

## Key Features Added

### Architecture Decision Record

- **ADR-002**: Formal decision record documenting the "no `matchmaking.notifications` topic" choice, including rationale (direct delivery path, targeted delivery via `TargetIDs`/`LobbyID`, operational simplicity), three alternatives evaluated, migration path for future adoption, and an ASCII architecture diagram

### Event Schema Documentation (EVENT_SCHEMAS.md)

- **Notification event descriptions**: Added `QueueStatusUpdated`, `MatchReady` (planned #26), and `MatchStarted` (planned #27) with payload details and delivery mechanism
- **Real-Time Notifications table**: New topic mapping section showing which notification events use `websocket.broadcasts`, their payload format (JSON), and delivery targets (`TargetIDs` or `LobbyID`)
- **Complete topic catalog**: Topic mapping reorganized into three clear sections — Domain Events (Protobuf), Real-Time Notifications (JSON), and Other Topics

### Infrastructure Alignment

- **`EventTypeMatchReady` constant**: Added placeholder event type for future #26 implementation
- **KafkaUser ACL comments**: Updated `matchmaking-producer` Strimzi manifest to reflect that `websocket.broadcasts` carries all notification events, with ADR-002 reference

## Architecture Highlights

**Design Patterns:**
- Architecture Decision Record (ADR) for traceable, reviewable infrastructure decisions
- Event-type routing within a shared topic (`websocket.broadcasts`) — logical separation via `type` field instead of physical topic segregation

**Key Components:**
- `ADR-002-notifications-topic-decision.md` — full decision context with architecture diagram, alternatives, and revisit criteria
- `EVENT_SCHEMAS.md` — now the single source of truth for all event routing, including notification events

**Security & Best Practices:**
- Existing `matchmaking-producer` KafkaUser ACLs already cover `websocket.broadcasts` (Write + Describe) — no ACL changes needed
- ADR documents clear criteria for when to reconsider (>3 consumers, non-WebSocket channels, rate limiting needs)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update

## Related Issue

Closes #20

## Test Plan

- [x] Build project: `go build ./...`
- [x] Run unit tests: `go test ./...`
- [ ] Run integration tests (if applicable)
- [ ] Manual testing performed
- [ ] All API endpoints tested
- [ ] Error handling verified
- [ ] Edge cases tested
- [ ] Performance tested (if applicable)
- [x] Security checks performed
- [x] No sensitive data in commits

### Test Steps

1. Verify build compiles: `go build ./...` — confirms the new `EventTypeMatchReady` constant is valid
2. Review ADR-002 for completeness: decision, rationale, architecture diagram, alternatives, migration path, revisit criteria
3. Review EVENT_SCHEMAS.md notification tables: verify all current and planned notification events are documented with correct topics and delivery mechanisms
4. Verify KafkaUser ACL comments align with ADR-002 decision

## Files Changed

- 4 files changed
- 162 insertions(+)
- 3 deletions(-)

## Database Migration

N/A

## Dependencies

- [x] No new dependencies added

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] All method names, comments, and documentation are in English
- [ ] OpenAPI specification updated (if API changes were made)
- [ ] Logging added for audit purposes (if applicable)

## Additional Notes

- This is primarily a **documentation PR** with one minor code addition (`EventTypeMatchReady` constant placeholder).
- The ADR includes an **ASCII architecture diagram** showing the notification flow: match-making-api producers → `websocket.broadcasts` → replay-api WebSocket hub → player connections.
- A **migration path** is documented in the ADR for when/if `matchmaking.notifications` is needed in the future (non-WebSocket channels, multiple consumers with different SLAs, etc.).
- The `EVENT_SCHEMAS.md` topic mapping now covers **all** topics in the codebase, not just Protobuf/CloudEvents ones.