### PR TITLE
feat: implement PlayerQueueConfirmed event handling and update schemas

### DIFF
--- a/.docs/EVENT_SCHEMAS.md
+++ b/.docs/EVENT_SCHEMAS.md
@@ -84,6 +84,23 @@ Emitted when a player leaves (cancels) the queue. Inverse of `PlayerQueued`. Con
 - Removes player from active queue store (Redis/Dragonfly)
 - If player is not in pool or active queue, the operation is a no-op (idempotent)
 
+### PlayerQueueConfirmed (match-making-api → replay-api)
+
+Emitted after adding a player to the matchmaking pool. Enables the async round-trip: join → PlayerQueued → pool add → PlayerQueueConfirmed → 200 OK (position/ETA) to the client.
+
+**Payload:**
+- `player_id`, `game_id`, `region` (required)
+- `position` (int32): queue position (1-based). 0 if match found immediately.
+- `eta_seconds` (int32): best-effort estimated wait in seconds. 0 if match found.
+- `tenant_id`, `client_id`, `resource_owner_id` (required)
+
+**Consumer (replay-api) behavior:**
+- Consume from `matchmaking.queue.confirmed`
+- Use `correlation_id` from envelope to associate with the original join request
+- Respond 200 OK with `{ position, eta_seconds }` to the client (or deliver via WebSocket/polling)
+
+**Approach:** Async. The replay-api produces PlayerQueued and returns 202 Accepted (or holds the connection). When it consumes PlayerQueueConfirmed, it responds 200 OK with position/ETA. Alternative: sync via request-reply over Kafka (replay-api blocks until PlayerQueueConfirmed with matching correlation_id) — not implemented; async is preferred for scalability.
+
 ### MatchCreated (match-making-api → replay-api)
 
 Emitted when a match is created.
@@ -129,6 +146,7 @@ Placeholder. Will notify players when the match has officially started. Publishe
 |-------|-----------|--------|---------------|----------------------|
 | `matchmaking.commands` | replay-api → match-making-api | PlayerQueued | `PlayerQueuedPayload` | 1 |
 | `matchmaking.commands` | replay-api → match-making-api | PlayerLeftQueue | `PlayerLeftQueuePayload` | 1 |
+| `matchmaking.queue.confirmed` | match-making-api → replay-api | PlayerQueueConfirmed | `PlayerQueueConfirmedPayload` | 1 |
 | `matchmaking.matches.created` | match-making-api → replay-api | MatchCreated | `MatchCreatedPayload` | 1 |
 | `matchmaking.matches` | match-making-api → replay-api | MatchCompleted | `MatchCompletedPayload` | 1 |
 | (TBD) | match-making-api → replay-api | RatingsUpdated | `RatingsUpdatedPayload` | 1 |

--- a/pkg/domain/pairing/usecases/matchmaking_event_consumer.go
+++ b/pkg/domain/pairing/usecases/matchmaking_event_consumer.go
@@ -14,6 +14,7 @@ import (
 	pairing_value_objects "github.com/leet-gaming/match-making-api/pkg/domain/pairing/value-objects"
 	"github.com/leet-gaming/match-making-api/pkg/infra/events/schemas"
 	"github.com/leet-gaming/match-making-api/pkg/infra/kafka"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // AddAndFindNextPairExecutor defines the interface for adding and finding pairs
@@ -24,6 +25,7 @@ type AddAndFindNextPairExecutor interface {
 // EventPublisherInterface defines the interface for publishing events
 type EventPublisherInterface interface {
 	PublishMatchCreated(ctx context.Context, event *kafka.MatchEvent) error
+	PublishPlayerQueueConfirmed(ctx context.Context, event *schemas.MatchmakingEvent) error
 }
 
 // MatchmakingEventConsumer consumes events from replay-api and processes them
@@ -482,6 +484,9 @@ func (c *MatchmakingEventConsumer) HandlePlayerQueuedProto(ctx context.Context, 
 			slog.ErrorContext(ctx, "Failed to publish match created event", "error", err, "pair_id", pair.ID)
 			// Don't return error — the match was created, just the notification failed
 		}
+
+		// Publish PlayerQueueConfirmed (position=0, eta=0 — match found immediately)
+		c.publishPlayerQueueConfirmed(ctx, envelope, payload, playerID, 0, 0)
 	} else {
 		// Register player in active queue for periodic position updates (#22)
 		if c.activeQueueStore != nil {
@@ -505,7 +510,67 @@ func (c *MatchmakingEventConsumer) HandlePlayerQueuedProto(ctx context.Context, 
 			"position", position,
 			"player_id", playerID,
 			"event_id", envelope.GetId())
+
+		// Publish PlayerQueueConfirmed with position and best-effort ETA
+		etaSeconds := c.estimateETA(position)
+		c.publishPlayerQueueConfirmed(ctx, envelope, payload, playerID, position, etaSeconds)
 	}
 
 	return nil
+}
+
+// estimateETA returns a best-effort estimated wait in seconds (e.g. ~30s per position).
+func (c *MatchmakingEventConsumer) estimateETA(position int) int32 {
+	if position <= 0 {
+		return 0
+	}
+	// Best-effort: ~30 seconds per queue position; cap at 5 minutes
+	eta := position * 30
+	if eta > 300 {
+		eta = 300
+	}
+	return int32(eta)
+}
+
+// publishPlayerQueueConfirmed builds and publishes a PlayerQueueConfirmed event.
+func (c *MatchmakingEventConsumer) publishPlayerQueueConfirmed(
+	ctx context.Context,
+	envelope *schemas.EventEnvelope,
+	payload *schemas.PlayerQueuedPayload,
+	playerID uuid.UUID,
+	position int,
+	etaSeconds int32,
+) {
+	confirmedEvent := &schemas.MatchmakingEvent{
+		Envelope: &schemas.EventEnvelope{
+			Id:                uuid.New().String(),
+			Type:              schemas.EventTypePlayerQueueConfirmed,
+			Source:             "match-making-api",
+			Specversion:        schemas.CloudEventsSpecVersion,
+			Time:               timestamppb.Now(),
+			Subject:            playerID.String(),
+			ResourceOwnerId:    envelope.GetResourceOwnerId(),
+			CorrelationId:      envelope.GetCorrelationId(),
+			DataschemaVersion:  schemas.SchemaVersionV1,
+		},
+		Data: &schemas.MatchmakingEvent_PlayerQueueConfirmed{
+			PlayerQueueConfirmed: &schemas.PlayerQueueConfirmedPayload{
+				PlayerId:         playerID.String(),
+				GameId:           payload.GetGameId(),
+				Region:           payload.GetRegion(),
+				Position:         int32(position),
+				EtaSeconds:       etaSeconds,
+				TenantId:         payload.GetTenantId(),
+				ClientId:         payload.GetClientId(),
+				ResourceOwnerId:  envelope.GetResourceOwnerId(),
+			},
+		},
+	}
+	if err := c.eventPublisher.PublishPlayerQueueConfirmed(ctx, confirmedEvent); err != nil {
+		slog.ErrorContext(ctx, "Failed to publish PlayerQueueConfirmed",
+			"error", err,
+			"player_id", playerID,
+			"event_id", envelope.GetId())
+		// Non-fatal — replay-api may use polling or WebSocket for status
+	}
 }

--- a/pkg/domain/pairing/usecases/matchmaking_event_consumer_test.go
+++ b/pkg/domain/pairing/usecases/matchmaking_event_consumer_test.go
@@ -42,6 +42,11 @@ func (m *MockEventPublisher) PublishMatchCreated(ctx context.Context, event *kaf
 	return args.Error(0)
 }
 
+func (m *MockEventPublisher) PublishPlayerQueueConfirmed(ctx context.Context, event *schemas.MatchmakingEvent) error {
+	args := m.Called(ctx, event)
+	return args.Error(0)
+}
+
 func TestMatchmakingEventConsumer_HandleQueueEvent(t *testing.T) {
 	ctx := context.Background()
 
@@ -630,7 +635,7 @@ func TestMatchmakingEventConsumer_HandlePlayerQueuedProto(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("Success - Player added to pool", func(t *testing.T) {
-		consumer, mockAddAndFind, _, mockRegionReader := newTestConsumer()
+		consumer, mockAddAndFind, mockEventPublisher, mockRegionReader := newTestConsumer()
 
 		playerID := uuid.New()
 		gameID := uuid.New()
@@ -678,12 +683,17 @@ func TestMatchmakingEventConsumer_HandlePlayerQueuedProto(t *testing.T) {
 				p.Criteria.SkillRange.MinMMR == 1300 &&
 				p.Criteria.SkillRange.MaxMMR == 1700
 		})).Return((*pairing_entities.Pair)(nil), pool, 1, nil)
+		mockEventPublisher.On("PublishPlayerQueueConfirmed", ctx, mock.MatchedBy(func(e *schemas.MatchmakingEvent) bool {
+			p := e.GetPlayerQueueConfirmed()
+			return p != nil && p.GetPlayerId() == playerID.String() && p.GetPosition() == 1 && p.GetEtaSeconds() == 30
+		})).Return(nil)
 
 		err := consumer.HandlePlayerQueuedProto(ctx, envelope, payload)
 
 		assert.NoError(t, err)
 		mockRegionReader.AssertExpectations(t)
 		mockAddAndFind.AssertExpectations(t)
+		mockEventPublisher.AssertExpectations(t)
 	})
 
 	t.Run("Success - Match found and MatchCreated published", func(t *testing.T) {
@@ -728,6 +738,10 @@ func TestMatchmakingEventConsumer_HandlePlayerQueuedProto(t *testing.T) {
 		mockAddAndFind.On("Execute", mock.Anything).Return(pair, pool, 1, nil)
 		mockEventPublisher.On("PublishMatchCreated", ctx, mock.MatchedBy(func(e *kafka.MatchEvent) bool {
 			return e.MatchID == pair.ID && len(e.PlayerIDs) == 2
+		})).Return(nil)
+		mockEventPublisher.On("PublishPlayerQueueConfirmed", ctx, mock.MatchedBy(func(e *schemas.MatchmakingEvent) bool {
+			p := e.GetPlayerQueueConfirmed()
+			return p != nil && p.GetPlayerId() == playerID.String() && p.GetPosition() == 0 && p.GetEtaSeconds() == 0
 		})).Return(nil)
 
 		err := consumer.HandlePlayerQueuedProto(ctx, envelope, payload)

--- a/pkg/infra/events/schemas/constants.go
+++ b/pkg/infra/events/schemas/constants.go
@@ -4,11 +4,12 @@ package schemas
 // Use these when setting EventEnvelope.Type to ensure consistency
 // between replay-api and match-making-api.
 const (
-	EventTypePlayerQueued    = "PlayerQueued"
-	EventTypePlayerLeftQueue = "PlayerLeftQueue"
-	EventTypeMatchCreated    = "MatchCreated"
-	EventTypeMatchCompleted  = "MatchCompleted"
-	EventTypeRatingsUpdated  = "RatingsUpdated"
+	EventTypePlayerQueued         = "PlayerQueued"
+	EventTypePlayerLeftQueue      = "PlayerLeftQueue"
+	EventTypePlayerQueueConfirmed = "PlayerQueueConfirmed"
+	EventTypeMatchCreated         = "MatchCreated"
+	EventTypeMatchCompleted       = "MatchCompleted"
+	EventTypeRatingsUpdated       = "RatingsUpdated"
 )
 
 // CloudEventsSpecVersion is the CloudEvents specification version (e.g. "1.0").

--- a/pkg/infra/events/schemas/matchmaking_events.pb.go
+++ b/pkg/infra/events/schemas/matchmaking_events.pb.go
@@ -144,6 +144,7 @@ type MatchmakingEvent struct {
 	//	*MatchmakingEvent_MatchCompleted
 	//	*MatchmakingEvent_RatingsUpdated
 	//	*MatchmakingEvent_PlayerLeftQueue
+	//	*MatchmakingEvent_PlayerQueueConfirmed
 	Data          isMatchmakingEvent_Data `protobuf_oneof:"data"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -238,6 +239,15 @@ func (x *MatchmakingEvent) GetPlayerLeftQueue() *PlayerLeftQueuePayload {
 	return nil
 }
 
+func (x *MatchmakingEvent) GetPlayerQueueConfirmed() *PlayerQueueConfirmedPayload {
+	if x != nil {
+		if x, ok := x.Data.(*MatchmakingEvent_PlayerQueueConfirmed); ok {
+			return x.PlayerQueueConfirmed
+		}
+	}
+	return nil
+}
+
 type isMatchmakingEvent_Data interface {
 	isMatchmakingEvent_Data()
 }
@@ -262,6 +272,10 @@ type MatchmakingEvent_PlayerLeftQueue struct {
 	PlayerLeftQueue *PlayerLeftQueuePayload `protobuf:"bytes,14,opt,name=player_left_queue,json=playerLeftQueue,proto3,oneof"`
 }
 
+type MatchmakingEvent_PlayerQueueConfirmed struct {
+	PlayerQueueConfirmed *PlayerQueueConfirmedPayload `protobuf:"bytes,15,opt,name=player_queue_confirmed,json=playerQueueConfirmed,proto3,oneof"`
+}
+
 func (*MatchmakingEvent_PlayerQueued) isMatchmakingEvent_Data() {}
 
 func (*MatchmakingEvent_MatchCreated) isMatchmakingEvent_Data() {}
@@ -271,6 +285,108 @@ func (*MatchmakingEvent_MatchCompleted) isMatchmakingEvent_Data() {}
 func (*MatchmakingEvent_RatingsUpdated) isMatchmakingEvent_Data() {}
 
 func (*MatchmakingEvent_PlayerLeftQueue) isMatchmakingEvent_Data() {}
+
+func (*MatchmakingEvent_PlayerQueueConfirmed) isMatchmakingEvent_Data() {}
+
+type PlayerQueueConfirmedPayload struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	PlayerId        string                 `protobuf:"bytes,1,opt,name=player_id,json=playerId,proto3" json:"player_id,omitempty"`
+	GameId          string                 `protobuf:"bytes,2,opt,name=game_id,json=gameId,proto3" json:"game_id,omitempty"`
+	Region          string                 `protobuf:"bytes,3,opt,name=region,proto3" json:"region,omitempty"`
+	Position        int32                  `protobuf:"varint,4,opt,name=position,proto3" json:"position,omitempty"`                       // Queue position (1-based). 0 if match found immediately.
+	EtaSeconds      int32                  `protobuf:"varint,5,opt,name=eta_seconds,json=etaSeconds,proto3" json:"eta_seconds,omitempty"` // Best-effort estimated wait in seconds. 0 if match found.
+	TenantId        string                 `protobuf:"bytes,6,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
+	ClientId        string                 `protobuf:"bytes,7,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"`
+	ResourceOwnerId string                 `protobuf:"bytes,8,opt,name=resource_owner_id,json=resourceOwnerId,proto3" json:"resource_owner_id,omitempty"` // From envelope; included for convenience.
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *PlayerQueueConfirmedPayload) Reset() {
+	*x = PlayerQueueConfirmedPayload{}
+	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PlayerQueueConfirmedPayload) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PlayerQueueConfirmedPayload) ProtoMessage() {}
+
+func (x *PlayerQueueConfirmedPayload) ProtoReflect() protoreflect.Message {
+	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PlayerQueueConfirmedPayload.ProtoReflect.Descriptor instead.
+func (*PlayerQueueConfirmedPayload) Descriptor() ([]byte, []int) {
+	return file_pkg_infra_events_schemas_matchmaking_events_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *PlayerQueueConfirmedPayload) GetPlayerId() string {
+	if x != nil {
+		return x.PlayerId
+	}
+	return ""
+}
+
+func (x *PlayerQueueConfirmedPayload) GetGameId() string {
+	if x != nil {
+		return x.GameId
+	}
+	return ""
+}
+
+func (x *PlayerQueueConfirmedPayload) GetRegion() string {
+	if x != nil {
+		return x.Region
+	}
+	return ""
+}
+
+func (x *PlayerQueueConfirmedPayload) GetPosition() int32 {
+	if x != nil {
+		return x.Position
+	}
+	return 0
+}
+
+func (x *PlayerQueueConfirmedPayload) GetEtaSeconds() int32 {
+	if x != nil {
+		return x.EtaSeconds
+	}
+	return 0
+}
+
+func (x *PlayerQueueConfirmedPayload) GetTenantId() string {
+	if x != nil {
+		return x.TenantId
+	}
+	return ""
+}
+
+func (x *PlayerQueueConfirmedPayload) GetClientId() string {
+	if x != nil {
+		return x.ClientId
+	}
+	return ""
+}
+
+func (x *PlayerQueueConfirmedPayload) GetResourceOwnerId() string {
+	if x != nil {
+		return x.ResourceOwnerId
+	}
+	return ""
+}
 
 type PlayerQueuedPayload struct {
 	state               protoimpl.MessageState `protogen:"open.v1"`
@@ -288,7 +404,7 @@ type PlayerQueuedPayload struct {
 
 func (x *PlayerQueuedPayload) Reset() {
 	*x = PlayerQueuedPayload{}
-	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[2]
+	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -300,7 +416,7 @@ func (x *PlayerQueuedPayload) String() string {
 func (*PlayerQueuedPayload) ProtoMessage() {}
 
 func (x *PlayerQueuedPayload) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[2]
+	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -313,7 +429,7 @@ func (x *PlayerQueuedPayload) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PlayerQueuedPayload.ProtoReflect.Descriptor instead.
 func (*PlayerQueuedPayload) Descriptor() ([]byte, []int) {
-	return file_pkg_infra_events_schemas_matchmaking_events_proto_rawDescGZIP(), []int{2}
+	return file_pkg_infra_events_schemas_matchmaking_events_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *PlayerQueuedPayload) GetPlayerId() string {
@@ -382,7 +498,7 @@ type SkillRange struct {
 
 func (x *SkillRange) Reset() {
 	*x = SkillRange{}
-	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[3]
+	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -394,7 +510,7 @@ func (x *SkillRange) String() string {
 func (*SkillRange) ProtoMessage() {}
 
 func (x *SkillRange) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[3]
+	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -407,7 +523,7 @@ func (x *SkillRange) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SkillRange.ProtoReflect.Descriptor instead.
 func (*SkillRange) Descriptor() ([]byte, []int) {
-	return file_pkg_infra_events_schemas_matchmaking_events_proto_rawDescGZIP(), []int{3}
+	return file_pkg_infra_events_schemas_matchmaking_events_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *SkillRange) GetMinMmr() int32 {
@@ -438,7 +554,7 @@ type PlayerLeftQueuePayload struct {
 
 func (x *PlayerLeftQueuePayload) Reset() {
 	*x = PlayerLeftQueuePayload{}
-	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[4]
+	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -450,7 +566,7 @@ func (x *PlayerLeftQueuePayload) String() string {
 func (*PlayerLeftQueuePayload) ProtoMessage() {}
 
 func (x *PlayerLeftQueuePayload) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[4]
+	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -463,7 +579,7 @@ func (x *PlayerLeftQueuePayload) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PlayerLeftQueuePayload.ProtoReflect.Descriptor instead.
 func (*PlayerLeftQueuePayload) Descriptor() ([]byte, []int) {
-	return file_pkg_infra_events_schemas_matchmaking_events_proto_rawDescGZIP(), []int{4}
+	return file_pkg_infra_events_schemas_matchmaking_events_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *PlayerLeftQueuePayload) GetPlayerId() string {
@@ -522,7 +638,7 @@ type MatchCreatedPayload struct {
 
 func (x *MatchCreatedPayload) Reset() {
 	*x = MatchCreatedPayload{}
-	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[5]
+	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -534,7 +650,7 @@ func (x *MatchCreatedPayload) String() string {
 func (*MatchCreatedPayload) ProtoMessage() {}
 
 func (x *MatchCreatedPayload) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[5]
+	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -547,7 +663,7 @@ func (x *MatchCreatedPayload) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MatchCreatedPayload.ProtoReflect.Descriptor instead.
 func (*MatchCreatedPayload) Descriptor() ([]byte, []int) {
-	return file_pkg_infra_events_schemas_matchmaking_events_proto_rawDescGZIP(), []int{5}
+	return file_pkg_infra_events_schemas_matchmaking_events_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *MatchCreatedPayload) GetMatchId() string {
@@ -603,7 +719,7 @@ type MatchPlayer struct {
 
 func (x *MatchPlayer) Reset() {
 	*x = MatchPlayer{}
-	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[6]
+	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -615,7 +731,7 @@ func (x *MatchPlayer) String() string {
 func (*MatchPlayer) ProtoMessage() {}
 
 func (x *MatchPlayer) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[6]
+	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -628,7 +744,7 @@ func (x *MatchPlayer) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MatchPlayer.ProtoReflect.Descriptor instead.
 func (*MatchPlayer) Descriptor() ([]byte, []int) {
-	return file_pkg_infra_events_schemas_matchmaking_events_proto_rawDescGZIP(), []int{6}
+	return file_pkg_infra_events_schemas_matchmaking_events_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *MatchPlayer) GetPlayerId() string {
@@ -663,7 +779,7 @@ type GameServer struct {
 
 func (x *GameServer) Reset() {
 	*x = GameServer{}
-	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[7]
+	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -675,7 +791,7 @@ func (x *GameServer) String() string {
 func (*GameServer) ProtoMessage() {}
 
 func (x *GameServer) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[7]
+	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -688,7 +804,7 @@ func (x *GameServer) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GameServer.ProtoReflect.Descriptor instead.
 func (*GameServer) Descriptor() ([]byte, []int) {
-	return file_pkg_infra_events_schemas_matchmaking_events_proto_rawDescGZIP(), []int{7}
+	return file_pkg_infra_events_schemas_matchmaking_events_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *GameServer) GetServerId() string {
@@ -727,7 +843,7 @@ type MatchCompletedPayload struct {
 
 func (x *MatchCompletedPayload) Reset() {
 	*x = MatchCompletedPayload{}
-	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[8]
+	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -739,7 +855,7 @@ func (x *MatchCompletedPayload) String() string {
 func (*MatchCompletedPayload) ProtoMessage() {}
 
 func (x *MatchCompletedPayload) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[8]
+	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -752,7 +868,7 @@ func (x *MatchCompletedPayload) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MatchCompletedPayload.ProtoReflect.Descriptor instead.
 func (*MatchCompletedPayload) Descriptor() ([]byte, []int) {
-	return file_pkg_infra_events_schemas_matchmaking_events_proto_rawDescGZIP(), []int{8}
+	return file_pkg_infra_events_schemas_matchmaking_events_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *MatchCompletedPayload) GetMatchId() string {
@@ -817,7 +933,7 @@ type RatingsUpdatedPayload struct {
 
 func (x *RatingsUpdatedPayload) Reset() {
 	*x = RatingsUpdatedPayload{}
-	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[9]
+	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -829,7 +945,7 @@ func (x *RatingsUpdatedPayload) String() string {
 func (*RatingsUpdatedPayload) ProtoMessage() {}
 
 func (x *RatingsUpdatedPayload) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[9]
+	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -842,7 +958,7 @@ func (x *RatingsUpdatedPayload) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RatingsUpdatedPayload.ProtoReflect.Descriptor instead.
 func (*RatingsUpdatedPayload) Descriptor() ([]byte, []int) {
-	return file_pkg_infra_events_schemas_matchmaking_events_proto_rawDescGZIP(), []int{9}
+	return file_pkg_infra_events_schemas_matchmaking_events_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *RatingsUpdatedPayload) GetMatchId() string {
@@ -892,7 +1008,7 @@ type PlayerRatingDelta struct {
 
 func (x *PlayerRatingDelta) Reset() {
 	*x = PlayerRatingDelta{}
-	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[10]
+	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -904,7 +1020,7 @@ func (x *PlayerRatingDelta) String() string {
 func (*PlayerRatingDelta) ProtoMessage() {}
 
 func (x *PlayerRatingDelta) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[10]
+	mi := &file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -917,7 +1033,7 @@ func (x *PlayerRatingDelta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PlayerRatingDelta.ProtoReflect.Descriptor instead.
 func (*PlayerRatingDelta) Descriptor() ([]byte, []int) {
-	return file_pkg_infra_events_schemas_matchmaking_events_proto_rawDescGZIP(), []int{10}
+	return file_pkg_infra_events_schemas_matchmaking_events_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *PlayerRatingDelta) GetPlayerId() string {
@@ -962,7 +1078,7 @@ const file_pkg_infra_events_schemas_matchmaking_events_proto_rawDesc = "" +
 	"\asubject\x18\x06 \x01(\tR\asubject\x12*\n" +
 	"\x11resource_owner_id\x18\a \x01(\tR\x0fresourceOwnerId\x12%\n" +
 	"\x0ecorrelation_id\x18\b \x01(\tR\rcorrelationId\x12-\n" +
-	"\x12dataschema_version\x18\t \x01(\x05R\x11dataschemaVersion\"\x91\x04\n" +
+	"\x12dataschema_version\x18\t \x01(\x05R\x11dataschemaVersion\"\xfd\x04\n" +
 	"\x10MatchmakingEvent\x12@\n" +
 	"\benvelope\x18\x01 \x01(\v2$.matchmaking.events.v1.EventEnvelopeR\benvelope\x12Q\n" +
 	"\rplayer_queued\x18\n" +
@@ -970,8 +1086,19 @@ const file_pkg_infra_events_schemas_matchmaking_events_proto_rawDesc = "" +
 	"\rmatch_created\x18\v \x01(\v2*.matchmaking.events.v1.MatchCreatedPayloadH\x00R\fmatchCreated\x12W\n" +
 	"\x0fmatch_completed\x18\f \x01(\v2,.matchmaking.events.v1.MatchCompletedPayloadH\x00R\x0ematchCompleted\x12W\n" +
 	"\x0fratings_updated\x18\r \x01(\v2,.matchmaking.events.v1.RatingsUpdatedPayloadH\x00R\x0eratingsUpdated\x12[\n" +
-	"\x11player_left_queue\x18\x0e \x01(\v2-.matchmaking.events.v1.PlayerLeftQueuePayloadH\x00R\x0fplayerLeftQueueB\x06\n" +
-	"\x04data\"\xe8\x02\n" +
+	"\x11player_left_queue\x18\x0e \x01(\v2-.matchmaking.events.v1.PlayerLeftQueuePayloadH\x00R\x0fplayerLeftQueue\x12j\n" +
+	"\x16player_queue_confirmed\x18\x0f \x01(\v22.matchmaking.events.v1.PlayerQueueConfirmedPayloadH\x00R\x14playerQueueConfirmedB\x06\n" +
+	"\x04data\"\x8e\x02\n" +
+	"\x1bPlayerQueueConfirmedPayload\x12\x1b\n" +
+	"\tplayer_id\x18\x01 \x01(\tR\bplayerId\x12\x17\n" +
+	"\agame_id\x18\x02 \x01(\tR\x06gameId\x12\x16\n" +
+	"\x06region\x18\x03 \x01(\tR\x06region\x12\x1a\n" +
+	"\bposition\x18\x04 \x01(\x05R\bposition\x12\x1f\n" +
+	"\veta_seconds\x18\x05 \x01(\x05R\n" +
+	"etaSeconds\x12\x1b\n" +
+	"\ttenant_id\x18\x06 \x01(\tR\btenantId\x12\x1b\n" +
+	"\tclient_id\x18\a \x01(\tR\bclientId\x12*\n" +
+	"\x11resource_owner_id\x18\b \x01(\tR\x0fresourceOwnerId\"\xe8\x02\n" +
 	"\x13PlayerQueuedPayload\x12\x1b\n" +
 	"\tplayer_id\x18\x01 \x01(\tR\bplayerId\x12\x17\n" +
 	"\agame_id\x18\x02 \x01(\tR\x06gameId\x12\x16\n" +
@@ -1046,38 +1173,40 @@ func file_pkg_infra_events_schemas_matchmaking_events_proto_rawDescGZIP() []byte
 	return file_pkg_infra_events_schemas_matchmaking_events_proto_rawDescData
 }
 
-var file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
+var file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
 var file_pkg_infra_events_schemas_matchmaking_events_proto_goTypes = []any{
-	(*EventEnvelope)(nil),          // 0: matchmaking.events.v1.EventEnvelope
-	(*MatchmakingEvent)(nil),       // 1: matchmaking.events.v1.MatchmakingEvent
-	(*PlayerQueuedPayload)(nil),    // 2: matchmaking.events.v1.PlayerQueuedPayload
-	(*SkillRange)(nil),             // 3: matchmaking.events.v1.SkillRange
-	(*PlayerLeftQueuePayload)(nil), // 4: matchmaking.events.v1.PlayerLeftQueuePayload
-	(*MatchCreatedPayload)(nil),    // 5: matchmaking.events.v1.MatchCreatedPayload
-	(*MatchPlayer)(nil),            // 6: matchmaking.events.v1.MatchPlayer
-	(*GameServer)(nil),             // 7: matchmaking.events.v1.GameServer
-	(*MatchCompletedPayload)(nil),  // 8: matchmaking.events.v1.MatchCompletedPayload
-	(*RatingsUpdatedPayload)(nil),  // 9: matchmaking.events.v1.RatingsUpdatedPayload
-	(*PlayerRatingDelta)(nil),      // 10: matchmaking.events.v1.PlayerRatingDelta
-	(*timestamppb.Timestamp)(nil),  // 11: google.protobuf.Timestamp
+	(*EventEnvelope)(nil),               // 0: matchmaking.events.v1.EventEnvelope
+	(*MatchmakingEvent)(nil),            // 1: matchmaking.events.v1.MatchmakingEvent
+	(*PlayerQueueConfirmedPayload)(nil), // 2: matchmaking.events.v1.PlayerQueueConfirmedPayload
+	(*PlayerQueuedPayload)(nil),         // 3: matchmaking.events.v1.PlayerQueuedPayload
+	(*SkillRange)(nil),                  // 4: matchmaking.events.v1.SkillRange
+	(*PlayerLeftQueuePayload)(nil),      // 5: matchmaking.events.v1.PlayerLeftQueuePayload
+	(*MatchCreatedPayload)(nil),         // 6: matchmaking.events.v1.MatchCreatedPayload
+	(*MatchPlayer)(nil),                 // 7: matchmaking.events.v1.MatchPlayer
+	(*GameServer)(nil),                  // 8: matchmaking.events.v1.GameServer
+	(*MatchCompletedPayload)(nil),       // 9: matchmaking.events.v1.MatchCompletedPayload
+	(*RatingsUpdatedPayload)(nil),       // 10: matchmaking.events.v1.RatingsUpdatedPayload
+	(*PlayerRatingDelta)(nil),           // 11: matchmaking.events.v1.PlayerRatingDelta
+	(*timestamppb.Timestamp)(nil),       // 12: google.protobuf.Timestamp
 }
 var file_pkg_infra_events_schemas_matchmaking_events_proto_depIdxs = []int32{
-	11, // 0: matchmaking.events.v1.EventEnvelope.time:type_name -> google.protobuf.Timestamp
+	12, // 0: matchmaking.events.v1.EventEnvelope.time:type_name -> google.protobuf.Timestamp
 	0,  // 1: matchmaking.events.v1.MatchmakingEvent.envelope:type_name -> matchmaking.events.v1.EventEnvelope
-	2,  // 2: matchmaking.events.v1.MatchmakingEvent.player_queued:type_name -> matchmaking.events.v1.PlayerQueuedPayload
-	5,  // 3: matchmaking.events.v1.MatchmakingEvent.match_created:type_name -> matchmaking.events.v1.MatchCreatedPayload
-	8,  // 4: matchmaking.events.v1.MatchmakingEvent.match_completed:type_name -> matchmaking.events.v1.MatchCompletedPayload
-	9,  // 5: matchmaking.events.v1.MatchmakingEvent.ratings_updated:type_name -> matchmaking.events.v1.RatingsUpdatedPayload
-	4,  // 6: matchmaking.events.v1.MatchmakingEvent.player_left_queue:type_name -> matchmaking.events.v1.PlayerLeftQueuePayload
-	3,  // 7: matchmaking.events.v1.PlayerQueuedPayload.skill_range:type_name -> matchmaking.events.v1.SkillRange
-	6,  // 8: matchmaking.events.v1.MatchCreatedPayload.players:type_name -> matchmaking.events.v1.MatchPlayer
-	7,  // 9: matchmaking.events.v1.MatchCreatedPayload.game_server:type_name -> matchmaking.events.v1.GameServer
-	10, // 10: matchmaking.events.v1.RatingsUpdatedPayload.deltas:type_name -> matchmaking.events.v1.PlayerRatingDelta
-	11, // [11:11] is the sub-list for method output_type
-	11, // [11:11] is the sub-list for method input_type
-	11, // [11:11] is the sub-list for extension type_name
-	11, // [11:11] is the sub-list for extension extendee
-	0,  // [0:11] is the sub-list for field type_name
+	3,  // 2: matchmaking.events.v1.MatchmakingEvent.player_queued:type_name -> matchmaking.events.v1.PlayerQueuedPayload
+	6,  // 3: matchmaking.events.v1.MatchmakingEvent.match_created:type_name -> matchmaking.events.v1.MatchCreatedPayload
+	9,  // 4: matchmaking.events.v1.MatchmakingEvent.match_completed:type_name -> matchmaking.events.v1.MatchCompletedPayload
+	10, // 5: matchmaking.events.v1.MatchmakingEvent.ratings_updated:type_name -> matchmaking.events.v1.RatingsUpdatedPayload
+	5,  // 6: matchmaking.events.v1.MatchmakingEvent.player_left_queue:type_name -> matchmaking.events.v1.PlayerLeftQueuePayload
+	2,  // 7: matchmaking.events.v1.MatchmakingEvent.player_queue_confirmed:type_name -> matchmaking.events.v1.PlayerQueueConfirmedPayload
+	4,  // 8: matchmaking.events.v1.PlayerQueuedPayload.skill_range:type_name -> matchmaking.events.v1.SkillRange
+	7,  // 9: matchmaking.events.v1.MatchCreatedPayload.players:type_name -> matchmaking.events.v1.MatchPlayer
+	8,  // 10: matchmaking.events.v1.MatchCreatedPayload.game_server:type_name -> matchmaking.events.v1.GameServer
+	11, // 11: matchmaking.events.v1.RatingsUpdatedPayload.deltas:type_name -> matchmaking.events.v1.PlayerRatingDelta
+	12, // [12:12] is the sub-list for method output_type
+	12, // [12:12] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_pkg_infra_events_schemas_matchmaking_events_proto_init() }
@@ -1091,15 +1220,16 @@ func file_pkg_infra_events_schemas_matchmaking_events_proto_init() {
 		(*MatchmakingEvent_MatchCompleted)(nil),
 		(*MatchmakingEvent_RatingsUpdated)(nil),
 		(*MatchmakingEvent_PlayerLeftQueue)(nil),
+		(*MatchmakingEvent_PlayerQueueConfirmed)(nil),
 	}
-	file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[2].OneofWrappers = []any{}
+	file_pkg_infra_events_schemas_matchmaking_events_proto_msgTypes[3].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pkg_infra_events_schemas_matchmaking_events_proto_rawDesc), len(file_pkg_infra_events_schemas_matchmaking_events_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   11,
+			NumMessages:   12,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/infra/events/schemas/matchmaking_events.proto
+++ b/pkg/infra/events/schemas/matchmaking_events.proto
@@ -30,7 +30,23 @@ message MatchmakingEvent {
     MatchCompletedPayload match_completed = 12;
     RatingsUpdatedPayload ratings_updated = 13;
     PlayerLeftQueuePayload player_left_queue = 14;
+    PlayerQueueConfirmedPayload player_queue_confirmed = 15;
   }
+}
+
+// --- PlayerQueueConfirmed (match-making-api → replay-api) ---
+// Emitted after adding player to pool. replay-api consumes to respond 200 OK with position/ETA.
+// Enables async round-trip: join → PlayerQueued → pool add → PlayerQueueConfirmed → 200 OK.
+
+message PlayerQueueConfirmedPayload {
+  string player_id = 1;
+  string game_id = 2;
+  string region = 3;
+  int32 position = 4;           // Queue position (1-based). 0 if match found immediately.
+  int32 eta_seconds = 5;        // Best-effort estimated wait in seconds. 0 if match found.
+  string tenant_id = 6;
+  string client_id = 7;
+  string resource_owner_id = 8; // From envelope; included for convenience.
 }
 
 // --- PlayerQueued (replay-api → match-making-api) ---

--- a/pkg/infra/kafka/client.go
+++ b/pkg/infra/kafka/client.go
@@ -218,6 +218,39 @@ type Message struct {
 	Timestamp time.Time
 }
 
+// PublishBytes sends a message with raw bytes to the specified topic.
+// Used for protobuf/protojson serialized payloads.
+func (c *Client) PublishBytes(ctx context.Context, topic string, key string, value []byte, headers map[string]string) error {
+	kafkaHeaders := make([]kafka.Header, 0, len(headers)+1)
+	for k, v := range headers {
+		kafkaHeaders = append(kafkaHeaders, kafka.Header{Key: k, Value: []byte(v)})
+	}
+	kafkaHeaders = append(kafkaHeaders, kafka.Header{Key: "region", Value: []byte(c.config.Region)})
+
+	kafkaMsg := kafka.Message{
+		Key:     []byte(key),
+		Value:   value,
+		Headers: kafkaHeaders,
+		Time:    time.Now(),
+	}
+
+	writer := c.GetWriter(topic)
+	if err := writer.WriteMessages(ctx, kafkaMsg); err != nil {
+		slog.Error("Failed to publish message",
+			"topic", topic,
+			"key", key,
+			"error", err)
+		return fmt.Errorf("failed to write message: %w", err)
+	}
+
+	slog.Debug("Published message",
+		"topic", topic,
+		"key", key,
+		"region", c.config.Region)
+
+	return nil
+}
+
 // Publish sends a message to the specified topic
 func (c *Client) Publish(ctx context.Context, topic string, msg *Message) error {
 	value, err := json.Marshal(msg.Value)

--- a/pkg/infra/kafka/events.go
+++ b/pkg/infra/kafka/events.go
@@ -2,9 +2,12 @@ package kafka
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/leet-gaming/match-making-api/pkg/infra/events/schemas"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 // Topic constants for matchmaking events
@@ -21,6 +24,11 @@ const (
 	// TopicMatchmakingCommands is the topic for canonical protobuf/CloudEvents commands
 	// from replay-api (e.g. PlayerQueued). Consumed by match-making-api.
 	TopicMatchmakingCommands = "matchmaking.commands"
+
+	// TopicPlayerQueueConfirmed is the topic for PlayerQueueConfirmed events
+	// (match-making-api → replay-api). Emitted after adding player to pool.
+	// replay-api consumes to respond 200 OK with position/ETA to the client.
+	TopicPlayerQueueConfirmed = "matchmaking.queue.confirmed"
 )
 
 // Event types
@@ -207,6 +215,35 @@ type PlayerMatchStat struct {
 	Assists  int       `json:"assists"`
 	Score    int       `json:"score"`
 	MMRChange int      `json:"mmr_change"`
+}
+
+// PublishPlayerQueueConfirmed publishes a PlayerQueueConfirmed event (match-making-api → replay-api).
+// Emitted after adding player to pool. replay-api consumes to respond 200 OK with position/ETA.
+func (p *EventPublisher) PublishPlayerQueueConfirmed(ctx context.Context, event *schemas.MatchmakingEvent) error {
+	value, err := protojson.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("failed to marshal PlayerQueueConfirmed: %w", err)
+	}
+
+	key := ""
+	if env := event.GetEnvelope(); env != nil {
+		key = env.GetSubject()
+	}
+	if key == "" {
+		if payload := event.GetPlayerQueueConfirmed(); payload != nil {
+			key = payload.GetPlayerId()
+		}
+	}
+	if key == "" {
+		key = uuid.New().String()
+	}
+
+	headers := map[string]string{
+		"ce_type":   schemas.EventTypePlayerQueueConfirmed,
+		"ce_source": "match-making-api",
+	}
+
+	return p.client.PublishBytes(ctx, TopicPlayerQueueConfirmed, key, value, headers)
 }
 
 // PublishMatchCreated publishes a match creation event


### PR DESCRIPTION
---

## Summary

This PR implements the **PlayerQueueConfirmed** flow: match-making-api consumes `PlayerQueued`, adds the player to the pool, and produces `PlayerQueueConfirmed` (with queue position and ETA) so replay-api can respond 200 OK to the client.

## Key Features Added

### Event Schemas

- **PlayerQueueConfirmedPayload**: New protobuf message with `player_id`, `game_id`, `region`, `position`, `eta_seconds`, `tenant_id`, `client_id`, `resource_owner_id`
- **MatchmakingEvent**: New `oneof` variant `player_queue_confirmed = 15`
- **EventTypePlayerQueueConfirmed**: New constant for CloudEvents routing

### Kafka Producer

- **Topic `matchmaking.queue.confirmed`**: New topic for match-making-api → replay-api events
- **PublishBytes**: New `Client` method for publishing raw bytes (protojson)
- **PublishPlayerQueueConfirmed**: New `EventPublisher` method to serialize and publish `PlayerQueueConfirmed` events

### Matchmaking Flow

- **HandlePlayerQueuedProto**: Publishes `PlayerQueueConfirmed` after adding a player to the pool
- **Match found**: Publishes with `position=0`, `eta_seconds=0`
- **Queued**: Publishes with actual position and best-effort ETA (~30s per position, max 5 min)
- **Correlation**: Propagates `correlation_id` from the original `PlayerQueued` envelope for replay-api to correlate responses

### Infrastructure Improvements

- **Client.PublishBytes**: Supports publishing protobuf/protojson payloads without JSON marshalling

## Architecture Highlights

**Design Patterns:**
- Event-driven flow aligned with Epic §10 Phase 1 Event Storming
- CloudEvents 1.0 envelope with `correlation_id` for tracing
- Async flow: replay-api consumes `PlayerQueueConfirmed` and responds 200 OK (documented in EVENT_SCHEMAS.md)

**Key Components:**
- `matchmaking_event_consumer.go`: `publishPlayerQueueConfirmed`, `estimateETA`
- `events.go`: `PublishPlayerQueueConfirmed`, `TopicPlayerQueueConfirmed`
- `client.go`: `PublishBytes` for protobuf serialization

**Security & Best Practices:**
- `resource_owner_id` propagated from envelope
- No new external dependencies (uses existing `protojson`, `timestamppb`)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update

## Related Issue

Closes #24-2502-004 (PlayerQueueConfirmed flow)

## Test Plan

- [x] Build project: `go build ./...`
- [x] Run unit tests: `go test ./pkg/domain/pairing/usecases/...`
- [ ] Run integration tests (if applicable)
- [ ] Manual testing with Kafka (produce PlayerQueued, verify PlayerQueueConfirmed)
- [ ] All API endpoints tested
- [x] Error handling verified (non-fatal on publish failure)
- [x] Edge cases tested (match found vs queued, position/ETA)

### Test Steps

1. Run `protoc` to regenerate `matchmaking_events.pb.go` (if proto changed)
2. Run `go test ./pkg/domain/pairing/usecases/... -run HandlePlayerQueuedProto`
3. Start consumer: `./consumer-matchmaking-commands.exe`
4. Produce a `PlayerQueued` event to `matchmaking.commands`
5. Confirm `PlayerQueueConfirmed` is produced to `matchmaking.queue.confirmed`

## Files Changed

- 8 files changed
- ~200 insertions(+)
- ~20 deletions(-)

**Main files:**
- `pkg/infra/events/schemas/matchmaking_events.proto`
- `pkg/infra/events/schemas/matchmaking_events.pb.go`
- `pkg/infra/events/schemas/constants.go`
- `pkg/infra/kafka/events.go`
- `pkg/infra/kafka/client.go`
- `pkg/domain/pairing/usecases/matchmaking_event_consumer.go`
- `pkg/domain/pairing/usecases/matchmaking_event_consumer_test.go`
- `.docs/EVENT_SCHEMAS.md`

## Database Migration

N/A

## Dependencies

- [x] No new dependencies added
- [ ] New dependencies added (list below)
- [ ] Dependencies updated (list below)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] All method names, comments, and documentation are in English (as per `.cursorrules`)
- [ ] OpenAPI specification updated (if API changes were made)
- [x] Logging added for audit purposes (if applicable)

## Additional Notes

**replay-api (separate repo):** This PR only implements the producer. replay-api must consume from `matchmaking.queue.confirmed` and respond 200 OK with `{ position, eta_seconds }` to the client. The `correlation_id` in the envelope links the response to the original join request.

**Strimzi ACLs:** The existing `matchmaking-producer` KafkaUser uses the `matchmaking.` prefix, so `matchmaking.queue.confirmed` is already covered. No deploy changes required.