### PR TITLE
feat: implement match validation and MatchCreated event publishing

### DIFF
--- a/.docs/EVENT_SCHEMAS.md
+++ b/.docs/EVENT_SCHEMAS.md
@@ -103,12 +103,21 @@ Emitted after adding a player to the matchmaking pool. Enables the async round-t
 
 ### MatchCreated (match-making-api → replay-api)
 
-Emitted when a match is created.
+Emitted when a match is created. Flow: PotentialMatchFound (AddAndFindNextPair returns pair) → validation → MatchCreated.
 
 **Payload:**
 - `match_id`, `lobby_id`, `tenant_id`, `client_id` (required)
 - `players[]`: `player_id`, `party_id`, `resource_permissions`
-- `game_server`: `server_id`, `region`, `resource_owner_id`
+- `game_server`: `server_id` (placeholder until 2503-002), `region`, `resource_owner_id`
+
+**Validation (before publish):**
+- `resource_owner_id` present (envelope)
+- `tenant_id`, `client_id` present (required for downstream access control)
+- Pair exists with players and match_id
+
+**Resource ownership transfer:** `game_server.resource_owner_id` and envelope carry ownership context for replay-api / game server access control.
+
+**Failure modes:** Validation failure → log, skip MatchCreated (pair remains in DB). Produce failure → log, non-fatal (reconciliation may be needed).
 
 ### MatchCompleted (optional)
 

--- a/.docs/MATCH_CREATION_FLOW.md
+++ b/.docs/MATCH_CREATION_FLOW.md
@@ -1,0 +1,34 @@
+# Match Creation Flow
+
+End-to-end flow from PotentialMatchFound → validation → MatchCreated (Epic §10 Phase 2).
+
+## Flow
+
+1. **PotentialMatchFound** (implicit): `AddAndFindNextPair.Execute` returns a non-nil pair when `pool.Peek` dequeues enough compatible players.
+2. **Validation**: `MatchValidator` runs before producing MatchCreated:
+   - Resource ownership: `resource_owner_id` required
+   - Required fields: `tenant_id`, `client_id` for downstream access control
+   - Pair integrity: pair exists, has players, has match_id
+3. **MatchCreated**: Published to `matchmaking.matches.created` with full Protobuf payload (Epic §9).
+
+## Validation Rules
+
+| Rule | Description |
+|------|-------------|
+| ResourceOwnershipRule | `resource_owner_id` must be present in envelope |
+| RequiredFieldsRule | `tenant_id`, `client_id` must be present in payload |
+| PairIntegrityRule | Pair must exist, have players, and valid match_id |
+
+## Failure Modes
+
+| Failure | Handling |
+|---------|----------|
+| Validation failure | Log error, skip MatchCreated. Pair remains in DB. No orphaned MatchCreated. |
+| Produce failure | Log error, non-fatal. Match exists; replay-api may need reconciliation. |
+| Duplicate PotentialMatchFound | Idempotency: partition by `match_id`; consumers dedupe. Pair creation is single-shot per Peek. |
+
+## Idempotency
+
+- MatchCreated keyed by `match_id` for Kafka partitioning.
+- Consumers should dedupe by `match_id` when processing.
+- Duplicate Peek for same parties is prevented by pool state (parties removed on Peek).

--- a/pkg/domain/pairing/usecases/match_validator.go
+++ b/pkg/domain/pairing/usecases/match_validator.go
@@ -1,0 +1,94 @@
+package usecases
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	pairing_entities "github.com/leet-gaming/match-making-api/pkg/domain/pairing/entities"
+	"github.com/leet-gaming/match-making-api/pkg/infra/events/schemas"
+)
+
+// MatchValidationRule defines a validation rule for match creation.
+// Validation runs before producing MatchCreated (PotentialMatchFound → validation → MatchCreated).
+type MatchValidationRule interface {
+	Validate(ctx context.Context, params MatchValidationParams) error
+}
+
+// MatchValidationParams holds the context for match validation.
+type MatchValidationParams struct {
+	Pair            *pairing_entities.Pair
+	Envelope        *schemas.EventEnvelope
+	Payload         *schemas.PlayerQueuedPayload
+	ResourceOwnerID string
+	TenantID        string
+	ClientID        string
+}
+
+// MatchValidator runs all validation rules before MatchCreated is produced.
+type MatchValidator struct {
+	rules []MatchValidationRule
+}
+
+// NewMatchValidator creates a validator with the default rules.
+func NewMatchValidator() *MatchValidator {
+	return &MatchValidator{
+		rules: []MatchValidationRule{
+			&ResourceOwnershipRule{},
+			&RequiredFieldsRule{},
+			&PairIntegrityRule{},
+		},
+	}
+}
+
+// Validate runs all rules. Returns the first error encountered.
+func (v *MatchValidator) Validate(ctx context.Context, params MatchValidationParams) error {
+	for _, rule := range v.rules {
+		if err := rule.Validate(ctx, params); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ResourceOwnershipRule ensures resource_owner_id is present (Epic §9).
+type ResourceOwnershipRule struct{}
+
+func (r *ResourceOwnershipRule) Validate(_ context.Context, params MatchValidationParams) error {
+	if strings.TrimSpace(params.ResourceOwnerID) == "" {
+		return fmt.Errorf("match validation: resource_owner_id is required for MatchCreated")
+	}
+	return nil
+}
+
+// RequiredFieldsRule ensures tenant_id and client_id are present for downstream access control.
+type RequiredFieldsRule struct{}
+
+// Validate ensures tenant_id and client_id are present for downstream access control.
+func (r *RequiredFieldsRule) Validate(_ context.Context, params MatchValidationParams) error {
+	if strings.TrimSpace(params.TenantID) == "" {
+		return fmt.Errorf("match validation: tenant_id is required for MatchCreated")
+	}
+	if strings.TrimSpace(params.ClientID) == "" {
+		return fmt.Errorf("match validation: client_id is required for MatchCreated")
+	}
+	return nil
+}
+
+// PairIntegrityRule ensures the pair exists and has players.
+type PairIntegrityRule struct{}
+
+// Validate ensures the pair exists and has players.
+func (r *PairIntegrityRule) Validate(_ context.Context, params MatchValidationParams) error {
+	if params.Pair == nil {
+		return fmt.Errorf("match validation: pair is nil")
+	}
+	if len(params.Pair.Match) == 0 {
+		return fmt.Errorf("match validation: pair has no players")
+	}
+	if params.Pair.ID == uuid.Nil {
+		return fmt.Errorf("match validation: pair has no match_id")
+	}
+	return nil
+}

--- a/pkg/domain/pairing/usecases/match_validator_test.go
+++ b/pkg/domain/pairing/usecases/match_validator_test.go
@@ -1,0 +1,158 @@
+package usecases_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	pairing_entities "github.com/leet-gaming/match-making-api/pkg/domain/pairing/entities"
+	"github.com/leet-gaming/match-making-api/pkg/domain/pairing/usecases"
+	parties_entities "github.com/leet-gaming/match-making-api/pkg/domain/parties/entities"
+	"github.com/leet-gaming/match-making-api/pkg/infra/events/schemas"
+)
+
+func TestMatchValidator_Validate(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("Success - all rules pass", func(t *testing.T) {
+		validator := usecases.NewMatchValidator()
+		pair := &pairing_entities.Pair{
+			ID: uuid.New(),
+			Match: map[uuid.UUID]*parties_entities.Party{
+				uuid.New(): {ID: uuid.New()},
+				uuid.New(): {ID: uuid.New()},
+			},
+		}
+
+		params := usecases.MatchValidationParams{
+			Pair:            pair,
+			ResourceOwnerID: uuid.New().String(),
+			TenantID:        uuid.New().String(),
+			ClientID:        uuid.New().String(),
+		}
+
+		err := validator.Validate(ctx, params)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Failure - missing resource_owner_id", func(t *testing.T) {
+		validator := usecases.NewMatchValidator()
+		pair := &pairing_entities.Pair{
+			ID:    uuid.New(),
+			Match: map[uuid.UUID]*parties_entities.Party{uuid.New(): {ID: uuid.New()}},
+		}
+
+		params := usecases.MatchValidationParams{
+			Pair:            pair,
+			ResourceOwnerID: "",
+			TenantID:        uuid.New().String(),
+			ClientID:        uuid.New().String(),
+		}
+
+		err := validator.Validate(ctx, params)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "resource_owner_id")
+	})
+
+	t.Run("Failure - missing tenant_id", func(t *testing.T) {
+		validator := usecases.NewMatchValidator()
+		pair := &pairing_entities.Pair{
+			ID:    uuid.New(),
+			Match: map[uuid.UUID]*parties_entities.Party{uuid.New(): {ID: uuid.New()}},
+		}
+
+		params := usecases.MatchValidationParams{
+			Pair:            pair,
+			ResourceOwnerID: uuid.New().String(),
+			TenantID:        "",
+			ClientID:        uuid.New().String(),
+		}
+
+		err := validator.Validate(ctx, params)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "tenant_id")
+	})
+
+	t.Run("Failure - missing client_id", func(t *testing.T) {
+		validator := usecases.NewMatchValidator()
+		pair := &pairing_entities.Pair{
+			ID:    uuid.New(),
+			Match: map[uuid.UUID]*parties_entities.Party{uuid.New(): {ID: uuid.New()}},
+		}
+
+		params := usecases.MatchValidationParams{
+			Pair:            pair,
+			ResourceOwnerID: uuid.New().String(),
+			TenantID:        uuid.New().String(),
+			ClientID:        "",
+		}
+
+		err := validator.Validate(ctx, params)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "client_id")
+	})
+
+	t.Run("Failure - nil pair", func(t *testing.T) {
+		validator := usecases.NewMatchValidator()
+		params := usecases.MatchValidationParams{
+			Pair:            nil,
+			ResourceOwnerID: uuid.New().String(),
+			TenantID:        uuid.New().String(),
+			ClientID:        uuid.New().String(),
+		}
+
+		err := validator.Validate(ctx, params)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "pair is nil")
+	})
+
+	t.Run("Failure - empty pair", func(t *testing.T) {
+		validator := usecases.NewMatchValidator()
+		pair := &pairing_entities.Pair{
+			ID:    uuid.New(),
+			Match: map[uuid.UUID]*parties_entities.Party{},
+		}
+
+		params := usecases.MatchValidationParams{
+			Pair:            pair,
+			ResourceOwnerID: uuid.New().String(),
+			TenantID:        uuid.New().String(),
+			ClientID:        uuid.New().String(),
+		}
+
+		err := validator.Validate(ctx, params)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no players")
+	})
+}
+
+func TestMatchValidator_Validate_WithEnvelopeAndPayload(t *testing.T) {
+	ctx := context.Background()
+	validator := usecases.NewMatchValidator()
+
+	envelope := &schemas.EventEnvelope{
+		ResourceOwnerId: uuid.New().String(),
+	}
+	payload := &schemas.PlayerQueuedPayload{
+		TenantId: uuid.New().String(),
+		ClientId: uuid.New().String(),
+	}
+	pair := &pairing_entities.Pair{
+		ID:    uuid.New(),
+		Match: map[uuid.UUID]*parties_entities.Party{uuid.New(): {ID: uuid.New()}},
+	}
+
+	params := usecases.MatchValidationParams{
+		Pair:            pair,
+		Envelope:        envelope,
+		Payload:         payload,
+		ResourceOwnerID: envelope.GetResourceOwnerId(),
+		TenantID:        payload.GetTenantId(),
+		ClientID:        payload.GetClientId(),
+	}
+
+	err := validator.Validate(ctx, params)
+	assert.NoError(t, err)
+}

--- a/pkg/domain/pairing/usecases/matchmaking_event_consumer.go
+++ b/pkg/domain/pairing/usecases/matchmaking_event_consumer.go
@@ -25,6 +25,7 @@ type AddAndFindNextPairExecutor interface {
 // EventPublisherInterface defines the interface for publishing events
 type EventPublisherInterface interface {
 	PublishMatchCreated(ctx context.Context, event *kafka.MatchEvent) error
+	PublishMatchCreatedProto(ctx context.Context, event *schemas.MatchmakingEvent) error
 	PublishPlayerQueueConfirmed(ctx context.Context, event *schemas.MatchmakingEvent) error
 }
 
@@ -471,18 +472,30 @@ func (c *MatchmakingEventConsumer) HandlePlayerQueuedProto(ctx context.Context, 
 			playerIDs = append(playerIDs, pid)
 		}
 
-		// Publish match created event via legacy EventPublisher
-		matchEvent := &kafka.MatchEvent{
-			MatchID:   pair.ID,
-			LobbyID:   pair.ID,
-			EventType: kafka.EventTypeMatchCreated,
-			GameType:  payload.GetGameId(),
-			Region:    payload.GetRegion(),
-			PlayerIDs: playerIDs,
+		// Validate before producing MatchCreated (PotentialMatchFound → validation → MatchCreated)
+		validator := NewMatchValidator()
+		validationParams := MatchValidationParams{
+			Pair:            pair,
+			Envelope:        envelope,
+			Payload:         payload,
+			ResourceOwnerID: envelope.GetResourceOwnerId(),
+			TenantID:        payload.GetTenantId(),
+			ClientID:        payload.GetClientId(),
 		}
-		if err := c.eventPublisher.PublishMatchCreated(ctx, matchEvent); err != nil {
-			slog.ErrorContext(ctx, "Failed to publish match created event", "error", err, "pair_id", pair.ID)
-			// Don't return error — the match was created, just the notification failed
+		if err := validator.Validate(ctx, validationParams); err != nil {
+			slog.ErrorContext(ctx, "Match validation failed, skipping MatchCreated",
+				"error", err,
+				"pair_id", pair.ID,
+				"event_id", envelope.GetId())
+			// Pair already exists in DB; validation failure prevents publishing.
+			// No orphaned state: pair remains, replay-api won't allocate until MatchCreated.
+			// Consider reconciliation job for unpaired matches.
+		} else if err := c.publishMatchCreatedProto(ctx, envelope, payload, pair); err != nil {
+			slog.ErrorContext(ctx, "Failed to publish MatchCreated event",
+				"error", err,
+				"pair_id", pair.ID,
+				"event_id", envelope.GetId())
+			// Non-fatal: match exists, notification failed. Replay-api may need reconciliation.
 		}
 
 		// Publish PlayerQueueConfirmed (position=0, eta=0 — match found immediately)
@@ -530,6 +543,64 @@ func (c *MatchmakingEventConsumer) estimateETA(position int) int32 {
 		eta = 300
 	}
 	return int32(eta)
+}
+
+// publishMatchCreatedProto builds and publishes a MatchCreated event with full schema (Epic §9).
+// Resource ownership is transferred to game_server context for downstream access control.
+func (c *MatchmakingEventConsumer) publishMatchCreatedProto(
+	ctx context.Context,
+	envelope *schemas.EventEnvelope,
+	payload *schemas.PlayerQueuedPayload,
+	pair *pairing_entities.Pair,
+) error {
+	// Build players[] from pair.Match
+	players := make([]*schemas.MatchPlayer, 0, len(pair.Match))
+	for partyID := range pair.Match {
+		perms := []string{}
+		// Joining player's resource_permissions; others get empty (solo queue)
+		if partyID.String() == payload.GetPlayerId() {
+			perms = payload.GetResourcePermissions()
+		}
+		players = append(players, &schemas.MatchPlayer{
+			PlayerId:            partyID.String(),
+			PartyId:             partyID.String(), // Solo: party_id = player_id
+			ResourcePermissions: perms,
+		})
+	}
+
+	// Game server: placeholder until 2503-002 implements allocation.
+	// Resource ownership transferred for access control.
+	gameServer := &schemas.GameServer{
+		ServerId:        "", // To be allocated by replay-api / game server manager
+		Region:          payload.GetRegion(),
+		ResourceOwnerId: envelope.GetResourceOwnerId(),
+	}
+
+	matchCreatedEvent := &schemas.MatchmakingEvent{
+		Envelope: &schemas.EventEnvelope{
+			Id:                uuid.New().String(),
+			Type:              schemas.EventTypeMatchCreated,
+			Source:             "match-making-api",
+			Specversion:        schemas.CloudEventsSpecVersion,
+			Time:               timestamppb.Now(),
+			Subject:            pair.ID.String(),
+			ResourceOwnerId:    envelope.GetResourceOwnerId(),
+			CorrelationId:      envelope.GetCorrelationId(),
+			DataschemaVersion:  schemas.SchemaVersionV1,
+		},
+		Data: &schemas.MatchmakingEvent_MatchCreated{
+			MatchCreated: &schemas.MatchCreatedPayload{
+				MatchId:    pair.ID.String(),
+				Players:    players,
+				GameServer: gameServer,
+				LobbyId:    pair.ID.String(),
+				TenantId:   payload.GetTenantId(),
+				ClientId:   payload.GetClientId(),
+			},
+		},
+	}
+
+	return c.eventPublisher.PublishMatchCreatedProto(ctx, matchCreatedEvent)
 }
 
 // publishPlayerQueueConfirmed builds and publishes a PlayerQueueConfirmed event.

--- a/pkg/domain/pairing/usecases/matchmaking_event_consumer_test.go
+++ b/pkg/domain/pairing/usecases/matchmaking_event_consumer_test.go
@@ -42,6 +42,11 @@ func (m *MockEventPublisher) PublishMatchCreated(ctx context.Context, event *kaf
 	return args.Error(0)
 }
 
+func (m *MockEventPublisher) PublishMatchCreatedProto(ctx context.Context, event *schemas.MatchmakingEvent) error {
+	args := m.Called(ctx, event)
+	return args.Error(0)
+}
+
 func (m *MockEventPublisher) PublishPlayerQueueConfirmed(ctx context.Context, event *schemas.MatchmakingEvent) error {
 	args := m.Called(ctx, event)
 	return args.Error(0)
@@ -736,8 +741,11 @@ func TestMatchmakingEventConsumer_HandlePlayerQueuedProto(t *testing.T) {
 
 		mockRegionReader.On("Search", ctx, map[string]interface{}{"slug": regionSlug}).Return([]*game_entities.Region{region}, nil)
 		mockAddAndFind.On("Execute", mock.Anything).Return(pair, pool, 1, nil)
-		mockEventPublisher.On("PublishMatchCreated", ctx, mock.MatchedBy(func(e *kafka.MatchEvent) bool {
-			return e.MatchID == pair.ID && len(e.PlayerIDs) == 2
+		mockEventPublisher.On("PublishMatchCreatedProto", ctx, mock.MatchedBy(func(e *schemas.MatchmakingEvent) bool {
+			mc := e.GetMatchCreated()
+			return mc != nil && mc.GetMatchId() == pair.ID.String() && len(mc.GetPlayers()) == 2 &&
+				mc.GetGameServer() != nil && mc.GetGameServer().GetResourceOwnerId() != "" &&
+				mc.GetTenantId() != "" && mc.GetClientId() != ""
 		})).Return(nil)
 		mockEventPublisher.On("PublishPlayerQueueConfirmed", ctx, mock.MatchedBy(func(e *schemas.MatchmakingEvent) bool {
 			p := e.GetPlayerQueueConfirmed()
@@ -749,6 +757,56 @@ func TestMatchmakingEventConsumer_HandlePlayerQueuedProto(t *testing.T) {
 		assert.NoError(t, err)
 		mockRegionReader.AssertExpectations(t)
 		mockAddAndFind.AssertExpectations(t)
+		mockEventPublisher.AssertExpectations(t)
+	})
+
+	t.Run("Success - Match found but validation fails (missing tenant_id)", func(t *testing.T) {
+		consumer, mockAddAndFind, mockEventPublisher, mockRegionReader := newTestConsumer()
+
+		playerID := uuid.New()
+		gameID := uuid.New()
+		regionSlug := "eu-west-1"
+
+		region := &game_entities.Region{
+			Name: "EU West",
+			Slug: regionSlug,
+		}
+		region.ID = uuid.New()
+
+		envelope := &schemas.EventEnvelope{
+			Id:              uuid.New().String(),
+			Type:            schemas.EventTypePlayerQueued,
+			Source:          "replay-api",
+			Specversion:     schemas.CloudEventsSpecVersion,
+			ResourceOwnerId: uuid.New().String(),
+		}
+
+		payload := &schemas.PlayerQueuedPayload{
+			PlayerId: playerID.String(),
+			GameId:   gameID.String(),
+			Region:   regionSlug,
+			TenantId: "", // Missing - validation should fail
+			ClientId: uuid.New().String(),
+		}
+
+		pool := &pairing_entities.Pool{}
+		pair := &pairing_entities.Pair{
+			Match: map[uuid.UUID]*parties_entities.Party{
+				playerID:   {ID: playerID},
+				uuid.New(): {ID: uuid.New()},
+			},
+		}
+		pair.ID = uuid.New()
+
+		mockRegionReader.On("Search", ctx, map[string]interface{}{"slug": regionSlug}).Return([]*game_entities.Region{region}, nil)
+		mockAddAndFind.On("Execute", mock.Anything).Return(pair, pool, 1, nil)
+		// PublishMatchCreatedProto should NOT be called (validation fails)
+		mockEventPublisher.On("PublishPlayerQueueConfirmed", ctx, mock.Anything).Return(nil)
+
+		err := consumer.HandlePlayerQueuedProto(ctx, envelope, payload)
+
+		assert.NoError(t, err)
+		mockEventPublisher.AssertNotCalled(t, "PublishMatchCreatedProto", mock.Anything, mock.Anything)
 		mockEventPublisher.AssertExpectations(t)
 	})
 

--- a/pkg/infra/kafka/events.go
+++ b/pkg/infra/kafka/events.go
@@ -246,7 +246,32 @@ func (p *EventPublisher) PublishPlayerQueueConfirmed(ctx context.Context, event 
 	return p.client.PublishBytes(ctx, TopicPlayerQueueConfirmed, key, value, headers)
 }
 
-// PublishMatchCreated publishes a match creation event
+// PublishMatchCreatedProto publishes a MatchCreated event with full Protobuf payload (Epic §9).
+// Includes match_id, players[], game_server (with resource ownership), lobby_id, tenant_id, client_id.
+// Partition key: match_id for per-match ordering.
+func (p *EventPublisher) PublishMatchCreatedProto(ctx context.Context, event *schemas.MatchmakingEvent) error {
+	value, err := protojson.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("failed to marshal MatchCreated: %w", err)
+	}
+
+	key := ""
+	if payload := event.GetMatchCreated(); payload != nil {
+		key = payload.GetMatchId()
+	}
+	if key == "" {
+		key = uuid.New().String()
+	}
+
+	headers := map[string]string{
+		"ce_type":   schemas.EventTypeMatchCreated,
+		"ce_source": "match-making-api",
+	}
+
+	return p.client.PublishBytes(ctx, TopicMatchesCreated, key, value, headers)
+}
+
+// PublishMatchCreated publishes a match creation event (legacy JSON format)
 func (p *EventPublisher) PublishMatchCreated(ctx context.Context, event *MatchEvent) error {
 	event.EventID = uuid.New()
 	event.EventType = EventTypeMatchCreated


### PR DESCRIPTION
## Summary

This PR implements the **end-to-end match creation flow** (Epic §10 Phase 2): PotentialMatchFound → validation → MatchCreated. It adds match validation before publishing, publishes MatchCreated with the full Protobuf payload (Epic §9), and transfers resource ownership into the game server context for downstream access control.

## Key Features Added

### Match Validation

- **MatchValidator**: Validates matches before producing MatchCreated
- **ResourceOwnershipRule**: Ensures `resource_owner_id` is present
- **RequiredFieldsRule**: Ensures `tenant_id` and `client_id` are present for access control
- **PairIntegrityRule**: Ensures pair exists, has players, and a valid `match_id`

### MatchCreated Producer

- **PublishMatchCreatedProto**: Publishes MatchCreated to `matchmaking.matches.created` with full Protobuf payload
- **Payload**: `match_id`, `players[]` (player_id, party_id, resource_permissions), `game_server` (server_id placeholder, region, resource_owner_id), `lobby_id`, `tenant_id`, `client_id`
- **Partitioning**: Uses `match_id` as Kafka key for per-match ordering

### Resource Ownership Transfer

- **game_server.resource_owner_id**: Carries ownership context for replay-api / game server access control
- **Envelope**: Propagates `resource_owner_id`, `correlation_id` for tracing

### Failure Handling

- **Validation failure**: Logs error, skips MatchCreated (pair remains in DB)
- **Produce failure**: Logs error, non-fatal (reconciliation may be needed)

### Documentation

- **MATCH_CREATION_FLOW.md**: Flow, validation rules, failure modes, idempotency
- **EVENT_SCHEMAS.md**: MatchCreated validation and failure modes

## Architecture Highlights

**Design Patterns:**
- Event-driven flow aligned with Epic §10 Phase 2
- Pluggable validation rules via `MatchValidationRule`
- CloudEvents 1.0 envelope with resource ownership

**Key Components:**
- `match_validator.go`: Validation rules before MatchCreated
- `matchmaking_event_consumer.go`: `publishMatchCreatedProto`, validation integration
- `events.go`: `PublishMatchCreatedProto` (Protobuf serialization)

**Security & Best Practices:**
- Resource ownership enforced before publishing
- `tenant_id`, `client_id` required for downstream access control
- `game_server` placeholder until 2503-002 implements allocation

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update

## Related Issue

Closes #(match-creation-flow-issue)

## Test Plan

- [x] Build project: `go build ./...`
- [x] Run unit tests: `go test ./pkg/domain/pairing/usecases/...`
- [ ] Run integration tests (if applicable)
- [ ] Manual testing with Kafka (produce PlayerQueued, verify MatchCreated)
- [ ] All API endpoints tested
- [x] Error handling verified (validation failure, produce failure)
- [x] Edge cases tested (validation fails → no MatchCreated; success → full payload)

### Test Steps

1. Run `go test ./pkg/domain/pairing/usecases/... -run "MatchValidator|HandlePlayerQueuedProto"`
2. Start consumer: `./consumer-matchmaking-commands.exe`
3. Produce a `PlayerQueued` event with `tenant_id`, `client_id`, `resource_owner_id`
4. Verify `MatchCreated` is produced to `matchmaking.matches.created` with full Protobuf payload
5. Verify validation failure (e.g. empty `tenant_id`) skips MatchCreated

## Files Changed

- 7 files changed
- ~350 insertions(+)
- ~30 deletions(-)

**New files:** `match_validator.go`, `match_validator_test.go`, `.docs/MATCH_CREATION_FLOW.md`  
**Modified:** `matchmaking_event_consumer.go`, `matchmaking_event_consumer_test.go`, `events.go`, `EVENT_SCHEMAS.md`

## Database Migration

N/A

## Dependencies

- [x] No new dependencies added
- [ ] New dependencies added (list below)
- [ ] Dependencies updated (list below)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] All method names, comments, and documentation are in English (as per `.cursorrules`)
- [ ] OpenAPI specification updated (if API changes were made)
- [x] Logging added for audit purposes (if applicable)

## Additional Notes

**PotentialMatchFound:** The trigger is implicit: `AddAndFindNextPair.Execute` returning a non-nil pair when `pool.Peek` dequeues compatible players. No separate event is emitted.

**Legacy path:** `handleQueueJoined` (QueueEvent) still uses `PublishMatchCreated` (JSON) because `QueueEvent` lacks `tenant_id`/`client_id`. `HandlePlayerQueuedProto` uses the new Protobuf producer.

**replay-api:** Consumes from `matchmaking.matches.created`. `game_server.server_id` is empty until 2503-002 implements allocation; replay-api can allocate and emit `ServerAllocated` separately.