### PR TITLE
feat(ownership): nest resource_owner on lobby, ratings, match results (2508-001)

### DIFF
--- a/.docs/RESOURCE_OWNERSHIP_MIGRATION.md
+++ b/.docs/RESOURCE_OWNERSHIP_MIGRATION.md
@@ -1,0 +1,67 @@
+# Resource Ownership Migration — Refs 2508-001
+
+**Scope:** match-making-api MongoDB collections only.  
+**replay-api:** out of this PR — keep story `partial` until handoff.
+
+## Goal
+
+Canonical nested field `resource_owner: { tenant_id, client_id, group_id, user_id }` on persisted matchmaking documents, while **keeping flat** `tenant_id` / `client_id` / `creator_id` / `resource_owner_id` for dual-write and rollback.
+
+## Already on BaseEntity
+
+Entities embedding `common.BaseEntity` already have nested `resource_owner`: Pair, Invitation, Notification, Game, GameMode, Region, Commitment, etc.
+
+## Migrated in this story (MM)
+
+| Collection | Flat source | Nested target |
+|------------|-------------|-----------------|
+| `lobbies` | `tenant_id`, `client_id`, `creator_id` → user | `resource_owner.*` |
+| `player_ratings` | `tenant_id`, `client_id`, `resource_owner_id` | `resource_owner.*` |
+| `match_results` | same | `resource_owner.*` |
+
+Application code: `EnsureResourceOwner` / `ValidateOwnership` on write; helpers in `pkg/common/resource_owner_helpers.go`.
+
+## Backfill (mongosh)
+
+```bash
+mongosh "$MONGO_URI" --file deploy/migrations/2508-001-backfill-resource-owner.js
+```
+
+Script is **idempotent** (`$or` missing nested fields). Dry-run: set `DRY_RUN = true` at top of the file.
+
+## Validation query
+
+```javascript
+db.lobbies.countDocuments({
+  $or: [
+    { "resource_owner.tenant_id": { $exists: false } },
+    { "resource_owner.client_id": { $exists: false } },
+  ]
+})
+// expect 0 after successful backfill (for docs that have flat tenant_id)
+```
+
+## Rollback
+
+1. **Do not drop flat fields** during this phase.
+2. To undo nested field only:
+
+```javascript
+db.lobbies.updateMany({}, { $unset: { resource_owner: "" } })
+db.player_ratings.updateMany({}, { $unset: { resource_owner: "" } })
+db.match_results.updateMany({}, { $unset: { resource_owner: "" } })
+```
+
+3. Redeploy previous app version that ignores `resource_owner`.
+
+## Indexes (2508-002)
+
+Compound indexes on `resource_owner.tenant_id` / `client_id` are **out of scope** here — story 2508-002.
+
+## Not migrated (intentionally)
+
+| Entity | Reason |
+|--------|--------|
+| `Pool` | In-memory / ephemeral |
+| `Party` / `Peer` / `Match` stubs | Minimal IDs only; ownership flows via Pair / events |
+| `Schedule` | Not persisted with ownership yet |

--- a/deploy/migrations/2508-001-backfill-resource-owner.js
+++ b/deploy/migrations/2508-001-backfill-resource-owner.js
@@ -1,0 +1,61 @@
+// 2508-001 — Backfill nested resource_owner where flat fields are already UUIDs.
+// Idempotent. Set DRY_RUN = true to only print counts.
+//
+// player_ratings / match_results keep string flat IDs; nested UUID resource_owner
+// is written by the application on next Save (EnsureResourceOwner + dual-write).
+// This script backfills lobbies only (UUID-typed flat fields).
+//
+// Usage:
+//   mongosh "$MONGO_URI/$DB_NAME" --file deploy/migrations/2508-001-backfill-resource-owner.js
+
+const DRY_RUN = false;
+
+function backfillLobbies() {
+  const filter = {
+    $or: [
+      { resource_owner: { $exists: false } },
+      { "resource_owner.tenant_id": { $exists: false } },
+      { "resource_owner.tenant_id": null },
+    ],
+    tenant_id: { $exists: true, $ne: null },
+    client_id: { $exists: true, $ne: null },
+  };
+  const count = db.lobbies.countDocuments(filter);
+  print(`lobbies to backfill: ${count}`);
+  if (DRY_RUN || count === 0) return;
+  const res = db.lobbies.updateMany(filter, [
+    {
+      $set: {
+        resource_owner: {
+          tenant_id: "$tenant_id",
+          client_id: "$client_id",
+          group_id: { $literal: null },
+          user_id: "$creator_id",
+        },
+      },
+    },
+  ]);
+  printjson(res);
+}
+
+function countRatingsMissingNested() {
+  const n = db.player_ratings.countDocuments({
+    resource_owner: { $exists: false },
+    tenant_id: { $exists: true, $ne: "" },
+  });
+  print(`player_ratings without nested resource_owner (app dual-writes on Save): ${n}`);
+}
+
+function countMatchResultsMissingNested() {
+  const n = db.match_results.countDocuments({
+    resource_owner: { $exists: false },
+    tenant_id: { $exists: true, $ne: "" },
+  });
+  print(`match_results without nested resource_owner (app dual-writes on Save): ${n}`);
+}
+
+print("=== 2508-001 resource_owner backfill ===");
+backfillLobbies();
+countRatingsMissingNested();
+countMatchResultsMissingNested();
+print("=== done ===");

--- a/pkg/common/resource_owner_helpers.go
+++ b/pkg/common/resource_owner_helpers.go
@@ -1,0 +1,57 @@
+package common
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// ErrMissingResourceOwnership is returned when required ownership fields are absent.
+var ErrMissingResourceOwnership = fmt.Errorf("resource ownership requires tenant_id and client_id")
+
+// ValidateTenantClient requires TenantID and ClientID (matchmaking integration baseline).
+func (ro ResourceOwner) ValidateTenantClient() error {
+	if ro.TenantID == uuid.Nil || ro.ClientID == uuid.Nil {
+		return ErrMissingResourceOwnership
+	}
+	return nil
+}
+
+// ParseUUIDOrNil parses s as UUID; empty or invalid returns uuid.Nil (no error).
+func ParseUUIDOrNil(s string) uuid.UUID {
+	if s == "" {
+		return uuid.Nil
+	}
+	id, err := uuid.Parse(s)
+	if err != nil {
+		return uuid.Nil
+	}
+	return id
+}
+
+// ResourceOwnerFromFlat builds ResourceOwner from string IDs used in event payloads / legacy docs.
+func ResourceOwnerFromFlat(tenantID, clientID, groupID, userID string) ResourceOwner {
+	return ResourceOwner{
+		TenantID: ParseUUIDOrNil(tenantID),
+		ClientID: ParseUUIDOrNil(clientID),
+		GroupID:  ParseUUIDOrNil(groupID),
+		UserID:   ParseUUIDOrNil(userID),
+	}
+}
+
+// FlatStrings returns tenant/client/group/user as strings (empty when Nil).
+func (ro ResourceOwner) FlatStrings() (tenantID, clientID, groupID, userID string) {
+	if ro.TenantID != uuid.Nil {
+		tenantID = ro.TenantID.String()
+	}
+	if ro.ClientID != uuid.Nil {
+		clientID = ro.ClientID.String()
+	}
+	if ro.GroupID != uuid.Nil {
+		groupID = ro.GroupID.String()
+	}
+	if ro.UserID != uuid.Nil {
+		userID = ro.UserID.String()
+	}
+	return
+}

--- a/pkg/common/resource_owner_helpers_test.go
+++ b/pkg/common/resource_owner_helpers_test.go
@@ -1,0 +1,32 @@
+package common
+
+import "testing"
+
+func TestResourceOwner_ValidateTenantClient(t *testing.T) {
+	t.Parallel()
+	ok := ResourceOwner{
+		TenantID: ParseUUIDOrNil("11111111-1111-1111-1111-111111111111"),
+		ClientID: ParseUUIDOrNil("22222222-2222-2222-2222-222222222222"),
+	}
+	if err := ok.ValidateTenantClient(); err != nil {
+		t.Fatalf("expected valid ownership, got %v", err)
+	}
+	if err := (ResourceOwner{}).ValidateTenantClient(); err == nil {
+		t.Fatal("expected error for empty ownership")
+	}
+}
+
+func TestResourceOwnerFromFlat_RoundTrip(t *testing.T) {
+	t.Parallel()
+	tenant := "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+	client := "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+	user := "cccccccc-cccc-cccc-cccc-cccccccccccc"
+	ro := ResourceOwnerFromFlat(tenant, client, "", user)
+	if err := ro.ValidateTenantClient(); err != nil {
+		t.Fatal(err)
+	}
+	gotT, gotC, _, gotU := ro.FlatStrings()
+	if gotT != tenant || gotC != client || gotU != user {
+		t.Fatalf("round-trip mismatch: %s %s %s", gotT, gotC, gotU)
+	}
+}

--- a/pkg/domain/lobbies/entities/lobby.go
+++ b/pkg/domain/lobbies/entities/lobby.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/leet-gaming/match-making-api/pkg/common"
 )
 
 // LobbyStatus represents the current state of a lobby
@@ -76,9 +77,11 @@ type QueueStats struct {
 type Lobby struct {
 	// Identity
 	ID        uuid.UUID `json:"id" bson:"_id"`
-	TenantID  uuid.UUID `json:"tenant_id" bson:"tenant_id"`
-	ClientID  uuid.UUID `json:"client_id" bson:"client_id"`
-	CreatorID uuid.UUID `json:"creator_id" bson:"creator_id"`
+	TenantID  uuid.UUID `json:"tenant_id" bson:"tenant_id"`   // dual-write with ResourceOwner (migration)
+	ClientID  uuid.UUID `json:"client_id" bson:"client_id"`   // dual-write with ResourceOwner (migration)
+	CreatorID uuid.UUID `json:"creator_id" bson:"creator_id"` // maps to ResourceOwner.UserID when owner is creator
+	// ResourceOwner is the canonical nested ownership (tenant/client/group/user).
+	ResourceOwner common.ResourceOwner `json:"resource_owner" bson:"resource_owner"`
 
 	// Game Configuration
 	GameID   string   `json:"game_id" bson:"game_id"`     // cs2, valorant, etc.
@@ -129,6 +132,35 @@ type Lobby struct {
 
 	// Metadata for extensibility
 	Metadata map[string]interface{} `json:"metadata,omitempty" bson:"metadata,omitempty"`
+}
+
+// EnsureResourceOwner fills nested resource_owner from flat fields (or the reverse)
+// so Mongo documents always dual-write during migration (Refs 2508-001).
+func (l *Lobby) EnsureResourceOwner() {
+	if l.ResourceOwner.TenantID == uuid.Nil {
+		l.ResourceOwner.TenantID = l.TenantID
+	}
+	if l.ResourceOwner.ClientID == uuid.Nil {
+		l.ResourceOwner.ClientID = l.ClientID
+	}
+	if l.ResourceOwner.UserID == uuid.Nil {
+		l.ResourceOwner.UserID = l.CreatorID
+	}
+	if l.TenantID == uuid.Nil {
+		l.TenantID = l.ResourceOwner.TenantID
+	}
+	if l.ClientID == uuid.Nil {
+		l.ClientID = l.ResourceOwner.ClientID
+	}
+	if l.CreatorID == uuid.Nil {
+		l.CreatorID = l.ResourceOwner.UserID
+	}
+}
+
+// ValidateOwnership rejects lobbies missing tenant/client on the canonical owner.
+func (l *Lobby) ValidateOwnership() error {
+	l.EnsureResourceOwner()
+	return l.ResourceOwner.ValidateTenantClient()
 }
 
 // GetCurrentPlayerCount returns the number of players in the lobby

--- a/pkg/domain/lobbies/entities/lobby_ownership_test.go
+++ b/pkg/domain/lobbies/entities/lobby_ownership_test.go
@@ -1,0 +1,29 @@
+package entities
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestLobby_EnsureResourceOwner_FromFlat(t *testing.T) {
+	t.Parallel()
+	tenant := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	client := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	creator := uuid.MustParse("33333333-3333-3333-3333-333333333333")
+	l := &Lobby{TenantID: tenant, ClientID: client, CreatorID: creator}
+	if err := l.ValidateOwnership(); err != nil {
+		t.Fatal(err)
+	}
+	if l.ResourceOwner.TenantID != tenant || l.ResourceOwner.ClientID != client || l.ResourceOwner.UserID != creator {
+		t.Fatalf("resource_owner not synced: %+v", l.ResourceOwner)
+	}
+}
+
+func TestLobby_ValidateOwnership_Missing(t *testing.T) {
+	t.Parallel()
+	l := &Lobby{}
+	if err := l.ValidateOwnership(); err == nil {
+		t.Fatal("expected missing ownership error")
+	}
+}

--- a/pkg/domain/pairing/entities/match_result.go
+++ b/pkg/domain/pairing/entities/match_result.go
@@ -4,20 +4,46 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/leet-gaming/match-making-api/pkg/common"
 )
 
 // MatchResult represents persisted match results with resource ownership.
 // Stored after consuming MatchCompleted; used for audit and access control.
 type MatchResult struct {
-	MatchID          uuid.UUID `json:"match_id" bson:"match_id"`
-	PlayerIDs        []string  `json:"player_ids" bson:"player_ids"`
-	WinnerTeamID     string    `json:"winner_team_id" bson:"winner_team_id"`
-	IsDraw           bool      `json:"is_draw" bson:"is_draw"`
-	CompletedAtMs    int64     `json:"completed_at_epoch_ms" bson:"completed_at_epoch_ms"`
-	CalculatedAtMs   int64     `json:"calculated_at_epoch_ms" bson:"calculated_at_epoch_ms"`
-	TenantID         string    `json:"tenant_id" bson:"tenant_id"`
-	ClientID         string    `json:"client_id" bson:"client_id"`
-	ResourceOwnerID  string    `json:"resource_owner_id" bson:"resource_owner_id"`
-	SourceEventID    string    `json:"source_event_id" bson:"source_event_id"` // MatchCompleted event_id for audit
-	CalculatedAt     time.Time `json:"calculated_at" bson:"calculated_at"`
+	MatchID         uuid.UUID `json:"match_id" bson:"match_id"`
+	PlayerIDs       []string  `json:"player_ids" bson:"player_ids"`
+	WinnerTeamID    string    `json:"winner_team_id" bson:"winner_team_id"`
+	IsDraw          bool      `json:"is_draw" bson:"is_draw"`
+	CompletedAtMs   int64     `json:"completed_at_epoch_ms" bson:"completed_at_epoch_ms"`
+	CalculatedAtMs  int64     `json:"calculated_at_epoch_ms" bson:"calculated_at_epoch_ms"`
+	TenantID        string    `json:"tenant_id" bson:"tenant_id"`
+	ClientID        string    `json:"client_id" bson:"client_id"`
+	ResourceOwnerID string    `json:"resource_owner_id" bson:"resource_owner_id"`
+	// ResourceOwner is the canonical nested ownership document (2508-001).
+	ResourceOwner  common.ResourceOwner `json:"resource_owner" bson:"resource_owner"`
+	SourceEventID  string               `json:"source_event_id" bson:"source_event_id"`
+	CalculatedAt   time.Time            `json:"calculated_at" bson:"calculated_at"`
+}
+
+// EnsureResourceOwner syncs nested ResourceOwner ↔ flat string IDs.
+func (m *MatchResult) EnsureResourceOwner() {
+	if m.ResourceOwner.TenantID == uuid.Nil && m.TenantID != "" {
+		m.ResourceOwner = common.ResourceOwnerFromFlat(m.TenantID, m.ClientID, "", m.ResourceOwnerID)
+	}
+	t, c, _, u := m.ResourceOwner.FlatStrings()
+	if m.TenantID == "" {
+		m.TenantID = t
+	}
+	if m.ClientID == "" {
+		m.ClientID = c
+	}
+	if m.ResourceOwnerID == "" {
+		m.ResourceOwnerID = u
+	}
+}
+
+// ValidateOwnership requires tenant + client after sync.
+func (m *MatchResult) ValidateOwnership() error {
+	m.EnsureResourceOwner()
+	return m.ResourceOwner.ValidateTenantClient()
 }

--- a/pkg/domain/pairing/entities/ownership_sync_test.go
+++ b/pkg/domain/pairing/entities/ownership_sync_test.go
@@ -1,0 +1,26 @@
+package entities
+
+import "testing"
+
+func TestPlayerRating_EnsureResourceOwner(t *testing.T) {
+	t.Parallel()
+	r := &PlayerRating{
+		TenantID:        "11111111-1111-1111-1111-111111111111",
+		ClientID:        "22222222-2222-2222-2222-222222222222",
+		ResourceOwnerID: "33333333-3333-3333-3333-333333333333",
+	}
+	if err := r.ValidateOwnership(); err != nil {
+		t.Fatal(err)
+	}
+	if r.ResourceOwner.TenantID.String() != r.TenantID {
+		t.Fatalf("tenant mismatch")
+	}
+}
+
+func TestMatchResult_ValidateOwnership_Missing(t *testing.T) {
+	t.Parallel()
+	m := &MatchResult{}
+	if err := m.ValidateOwnership(); err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/pkg/domain/pairing/entities/player_rating.go
+++ b/pkg/domain/pairing/entities/player_rating.go
@@ -4,18 +4,45 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/leet-gaming/match-making-api/pkg/common"
 )
 
 // PlayerRating represents a player's MMR/rating for a game, with resource ownership.
 // Stored per player_id + game_id + tenant_id + client_id; used for matchmaking and leaderboards.
 type PlayerRating struct {
-	PlayerID        string    `json:"player_id" bson:"player_id"`
-	GameID          string    `json:"game_id" bson:"game_id"` // Empty for global rating
-	TenantID        string    `json:"tenant_id" bson:"tenant_id"`
-	ClientID        string    `json:"client_id" bson:"client_id"`
-	ResourceOwnerID string    `json:"resource_owner_id" bson:"resource_owner_id"`
-	MMR             int32     `json:"mmr" bson:"mmr"`
-	UpdatedAt       time.Time `json:"updated_at" bson:"updated_at"`
+	PlayerID string `json:"player_id" bson:"player_id"`
+	GameID   string `json:"game_id" bson:"game_id"` // Empty for global rating
+	// Flat fields kept for dual-write / query keys during migration (2508-001).
+	TenantID        string `json:"tenant_id" bson:"tenant_id"`
+	ClientID        string `json:"client_id" bson:"client_id"`
+	ResourceOwnerID string `json:"resource_owner_id" bson:"resource_owner_id"`
+	// ResourceOwner is the canonical nested ownership document.
+	ResourceOwner common.ResourceOwner `json:"resource_owner" bson:"resource_owner"`
+	MMR           int32                `json:"mmr" bson:"mmr"`
+	UpdatedAt     time.Time            `json:"updated_at" bson:"updated_at"`
+}
+
+// EnsureResourceOwner syncs nested ResourceOwner ↔ flat string IDs.
+func (r *PlayerRating) EnsureResourceOwner() {
+	if r.ResourceOwner.TenantID == uuid.Nil && r.TenantID != "" {
+		r.ResourceOwner = common.ResourceOwnerFromFlat(r.TenantID, r.ClientID, "", r.ResourceOwnerID)
+	}
+	t, c, _, u := r.ResourceOwner.FlatStrings()
+	if r.TenantID == "" {
+		r.TenantID = t
+	}
+	if r.ClientID == "" {
+		r.ClientID = c
+	}
+	if r.ResourceOwnerID == "" {
+		r.ResourceOwnerID = u
+	}
+}
+
+// ValidateOwnership requires tenant + client after sync.
+func (r *PlayerRating) ValidateOwnership() error {
+	r.EnsureResourceOwner()
+	return r.ResourceOwner.ValidateTenantClient()
 }
 
 // RatingAuditEntry records a rating change for audit trail.

--- a/pkg/infra/db/mongodb/lobby_mongodb.go
+++ b/pkg/infra/db/mongodb/lobby_mongodb.go
@@ -111,6 +111,9 @@ func (r *LobbyRepository) ensureIndexes() {
 
 // Create inserts a new lobby
 func (r *LobbyRepository) Create(ctx context.Context, lobby *entities.Lobby) error {
+	if err := lobby.ValidateOwnership(); err != nil {
+		return fmt.Errorf("failed to create lobby: %w", err)
+	}
 	lobby.CreatedAt = time.Now()
 	lobby.UpdatedAt = time.Now()
 	
@@ -131,11 +134,15 @@ func (r *LobbyRepository) GetByID(ctx context.Context, id uuid.UUID) (*entities.
 		}
 		return nil, fmt.Errorf("failed to get lobby: %w", err)
 	}
+	lobby.EnsureResourceOwner()
 	return &lobby, nil
 }
 
 // Update updates an existing lobby
 func (r *LobbyRepository) Update(ctx context.Context, lobby *entities.Lobby) error {
+	if err := lobby.ValidateOwnership(); err != nil {
+		return fmt.Errorf("failed to update lobby: %w", err)
+	}
 	lobby.UpdatedAt = time.Now()
 	
 	_, err := r.collection.ReplaceOne(ctx, bson.M{"_id": lobby.ID}, lobby)

--- a/pkg/infra/db/mongodb/match_result_mongodb.go
+++ b/pkg/infra/db/mongodb/match_result_mongodb.go
@@ -32,6 +32,9 @@ func (r *matchResultRepository) collection() *mongo.Collection {
 
 // Save persists a match result. Idempotent: uses match_id as _id; if exists, returns existing.
 func (r *matchResultRepository) Save(ctx context.Context, result *entities.MatchResult) (*entities.MatchResult, error) {
+	if err := result.ValidateOwnership(); err != nil {
+		return nil, err
+	}
 	coll := r.collection()
 	matchIDStr := result.MatchID.String()
 
@@ -39,17 +42,23 @@ func (r *matchResultRepository) Save(ctx context.Context, result *entities.Match
 	filter := bson.M{"_id": matchIDStr}
 	update := bson.M{
 		"$setOnInsert": bson.M{
-			"_id":                   matchIDStr,
-			"player_ids":            result.PlayerIDs,
-			"winner_team_id":        result.WinnerTeamID,
-			"is_draw":               result.IsDraw,
-			"completed_at_epoch_ms": result.CompletedAtMs,
+			"_id":                    matchIDStr,
+			"player_ids":             result.PlayerIDs,
+			"winner_team_id":         result.WinnerTeamID,
+			"is_draw":                result.IsDraw,
+			"completed_at_epoch_ms":  result.CompletedAtMs,
 			"calculated_at_epoch_ms": result.CalculatedAtMs,
-			"tenant_id":             result.TenantID,
-			"client_id":             result.ClientID,
-			"resource_owner_id":     result.ResourceOwnerID,
-			"source_event_id":       result.SourceEventID,
-			"calculated_at":         result.CalculatedAt,
+			"tenant_id":              result.TenantID,
+			"client_id":              result.ClientID,
+			"resource_owner_id":      result.ResourceOwnerID,
+			"resource_owner": bson.M{
+				"tenant_id": result.ResourceOwner.TenantID,
+				"client_id": result.ResourceOwner.ClientID,
+				"group_id":  result.ResourceOwner.GroupID,
+				"user_id":   result.ResourceOwner.UserID,
+			},
+			"source_event_id": result.SourceEventID,
+			"calculated_at":   result.CalculatedAt,
 		},
 	}
 
@@ -97,7 +106,7 @@ func (r *matchResultRepository) GetByMatchID(ctx context.Context, matchID uuid.U
 		return nil, err
 	}
 
-	return &entities.MatchResult{
+	out := &entities.MatchResult{
 		MatchID:         matchID,
 		PlayerIDs:       doc.PlayerIDs,
 		WinnerTeamID:    doc.WinnerTeamID,
@@ -108,5 +117,7 @@ func (r *matchResultRepository) GetByMatchID(ctx context.Context, matchID uuid.U
 		ClientID:        doc.ClientID,
 		ResourceOwnerID: doc.ResourceOwnerID,
 		SourceEventID:   doc.SourceEventID,
-	}, nil
+	}
+	out.EnsureResourceOwner()
+	return out, nil
 }

--- a/pkg/infra/db/mongodb/player_rating_mongodb.go
+++ b/pkg/infra/db/mongodb/player_rating_mongodb.go
@@ -67,7 +67,7 @@ func (r *playerRatingRepository) GetByPlayer(ctx context.Context, playerID, game
 		return nil, err
 	}
 
-	return &entities.PlayerRating{
+	rating := &entities.PlayerRating{
 		PlayerID:        doc.PlayerID,
 		GameID:          doc.GameID,
 		TenantID:        doc.TenantID,
@@ -75,11 +75,16 @@ func (r *playerRatingRepository) GetByPlayer(ctx context.Context, playerID, game
 		ResourceOwnerID: doc.ResourceOwnerID,
 		MMR:             doc.MMR,
 		UpdatedAt:       doc.UpdatedAt,
-	}, nil
+	}
+	rating.EnsureResourceOwner()
+	return rating, nil
 }
 
 // Save upserts the player's rating.
 func (r *playerRatingRepository) Save(ctx context.Context, rating *entities.PlayerRating) error {
+	if err := rating.ValidateOwnership(); err != nil {
+		return err
+	}
 	coll := r.ratingsColl()
 	key := ratingDocKey(rating.PlayerID, rating.GameID, rating.TenantID, rating.ClientID)
 	rating.UpdatedAt = time.Now().UTC()
@@ -87,14 +92,20 @@ func (r *playerRatingRepository) Save(ctx context.Context, rating *entities.Play
 	filter := bson.M{"_id": key}
 	update := bson.M{
 		"$set": bson.M{
-			"_id":                   key,
-			"player_id":             rating.PlayerID,
-			"game_id":               rating.GameID,
-			"tenant_id":             rating.TenantID,
-			"client_id":             rating.ClientID,
-			"resource_owner_id":     rating.ResourceOwnerID,
-			"mmr":                   rating.MMR,
-			"updated_at":            rating.UpdatedAt,
+			"_id":               key,
+			"player_id":         rating.PlayerID,
+			"game_id":           rating.GameID,
+			"tenant_id":         rating.TenantID,
+			"client_id":         rating.ClientID,
+			"resource_owner_id": rating.ResourceOwnerID,
+			"resource_owner": bson.M{
+				"tenant_id": rating.ResourceOwner.TenantID,
+				"client_id": rating.ResourceOwner.ClientID,
+				"group_id":  rating.ResourceOwner.GroupID,
+				"user_id":   rating.ResourceOwner.UserID,
+			},
+			"mmr":        rating.MMR,
+			"updated_at": rating.UpdatedAt,
 		},
 	}
 


### PR DESCRIPTION
## Summary

This PR aligns match-making-api persistence with the Resource Ownership framework (tenant_id, client_id, group_id, user_id): nested `resource_owner` on Lobby, PlayerRating, and MatchResult with dual-write of legacy flat fields, validation on write paths, mongosh backfill for lobbies, and rollback documentation.

Refs 2508-001.

## Key Features Added

### Domain Ownership Alignment

- **Lobby**: nested `resource_owner` synced from/to flat `tenant_id`, `client_id`, `creator_id`; `ValidateOwnership` on create/update
- **PlayerRating / MatchResult**: nested `resource_owner` dual-written on Save; `EnsureResourceOwner` on read from flat string IDs
- **Helpers**: `ValidateTenantClient`, `ResourceOwnerFromFlat`, `FlatStrings` in `pkg/common`

### Migration & Ops

- **Backfill script**: `deploy/migrations/2508-001-backfill-resource-owner.js` (lobbies UUID fields; ratings/results dual-write on next Save)
- **Operator guide**: `.docs/RESOURCE_OWNERSHIP_MIGRATION.md` — goal, validation queries, rollback (`$unset resource_owner`)

### Infrastructure Improvements

- Lobby Mongo repository rejects create/update without tenant+client
- No new indexes in this PR (Indexes → Refs 2508-002)

## Architecture Highlights

**Design Patterns:**

- Dual-write migration: nested canonical `resource_owner` + flat fields retained for rollback
- Entities embedding `common.BaseEntity` already had nested ownership; this PR covers collections that used flat IDs only

**Key Components:**

- `pkg/common/resource_owner_helpers.go` — parse/validate helpers
- `pkg/domain/lobbies/entities/lobby.go` — EnsureResourceOwner / ValidateOwnership
- `pkg/infra/db/mongodb/{lobby,player_rating,match_result}_mongodb.go` — persist nested document

**Security & Best Practices:**

- Writes require tenant_id + client_id
- Flat fields not dropped in this phase (safe rollback)
- No PII beyond existing ownership IDs

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test addition or update

## Related Issue

Refs 2508-001

## Test Plan

- [x] Build project: `go build ./...` (targeted packages compiled via tests)
- [x] Run unit tests: `go test ./pkg/common/... ./pkg/domain/lobbies/entities/... ./pkg/domain/pairing/entities/...` — PASS
- [ ] Run integration tests (if applicable)
- [ ] Manual testing performed
- [ ] All API endpoints tested
- [x] Error handling verified (missing ownership rejected on write)
- [x] Edge cases tested (empty ownership, sync from flat)
- [ ] Performance tested (if applicable)
- [ ] Security checks performed
- [x] No sensitive data in commits

### Test Steps

1. `go test ./pkg/common/... ./pkg/domain/lobbies/entities/... ./pkg/domain/pairing/entities/...`
2. (Optional, staging) `mongosh "$MONGO_URI/$DB" --file deploy/migrations/2508-001-backfill-resource-owner.js` with `DRY_RUN = true` first
3. Create/update a lobby via API or repo — confirm document has both flat IDs and nested `resource_owner`

## Files Changed

- 12 files changed
- 429 insertions(+)
- 43 deletions(-)

## Database Migration

After deploy (staging/prod), backfill lobbies:

```bash
mongosh "$MONGO_URI/$DB_NAME" --file deploy/migrations/2508-001-backfill-resource-owner.js
```

Set `DRY_RUN = true` in the script first to print counts. Rollback: `$unset: { resource_owner: "" }` on affected collections (see `.docs/RESOURCE_OWNERSHIP_MIGRATION.md`). Flat fields remain.

## Dependencies

- [x] No new dependencies added
- [ ] New dependencies added (list below)
- [ ] Dependencies updated (list below)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] All method names, comments, and documentation are in English (as per `.cursorrules`)
- [ ] OpenAPI specification updated (if API changes were made)
- [ ] Logging added for audit purposes (if applicable)

## Additional Notes

- Story remains **partial** until env backfill is run and any replay-api ownership alignment is confirmed separately (not in this PR).
- Compound indexes on `resource_owner.*` are tracked as Refs 2508-002.
- Suggested PR title: `feat(ownership): nest resource_owner on lobby, ratings, match results (2508-001)`
- Base branch: `develop`
- Feature branch: `37-2508-001-add-resource-ownership-to-entities`
