### PR TITLE
feat(ownership): add resource_owner Mongo indexes (2508-002)

### DIFF
--- a/.docs/RESOURCE_OWNERSHIP_INDEXES.md
+++ b/.docs/RESOURCE_OWNERSHIP_INDEXES.md
@@ -1,0 +1,43 @@
+# Resource Ownership Indexes — Refs 2508-002
+
+**Scope:** match-making-api only. replay-api indexes are a separate handoff.
+
+## Strategy
+
+| Index name | Keys | Collections |
+|------------|------|-------------|
+| `idx_ro_tenant_client` | `resource_owner.tenant_id`, `resource_owner.client_id` | lobbies, player_ratings, match_results, commitments, push_tokens, game_connection_info |
+| `idx_ro_tenant_user` | `resource_owner.tenant_id`, `resource_owner.user_id` | same |
+| `idx_ro_tenant_group` | `resource_owner.tenant_id`, `resource_owner.group_id` | same |
+| `idx_flat_tenant_client` | `tenant_id`, `client_id` | lobbies, player_ratings, match_results (dual-write) |
+
+Defined in `pkg/infra/db/mongodb/resource_ownership_indexes.go` and applied via `EnsureResourceOwnershipIndexes` when repositories start.
+
+## Validation (app layer)
+
+- Lobby create/update: `ValidateOwnership()` (tenant + client required) — Refs 2508-001
+- PlayerRating / MatchResult Save: same
+- Invalid ownership → repository returns error before write
+
+## Performance smoke (manual / staging)
+
+Epic target: ownership-filtered queries **&lt; 50ms** (p95). After deploy:
+
+```javascript
+// mongosh — confirm indexes
+db.lobbies.getIndexes().filter(i => i.name && i.name.startsWith("idx_ro"))
+
+// explain — should use idx_ro_tenant_client
+db.lobbies.find({
+  "resource_owner.tenant_id": UUID("…"),
+  "resource_owner.client_id": UUID("…")
+}).explain("executionStats")
+```
+
+Record `executionStats.executionTimeMillis` in the PR or runbook if &gt; 50ms on representative data.
+
+## Out of scope
+
+- Data backfill → 2508-001
+- Session–Pool mapping → 2508-003
+- replay-api collections → handoff

--- a/.docs/RESOURCE_OWNERSHIP_MIGRATION.md
+++ b/.docs/RESOURCE_OWNERSHIP_MIGRATION.md
@@ -56,7 +56,7 @@ db.match_results.updateMany({}, { $unset: { resource_owner: "" } })
 
 ## Indexes (2508-002)
 
-Compound indexes on `resource_owner.tenant_id` / `client_id` are **out of scope** here — story 2508-002.
+Compound indexes on `resource_owner.*` (and flat dual-write keys): see [.docs/RESOURCE_OWNERSHIP_INDEXES.md](RESOURCE_OWNERSHIP_INDEXES.md).
 
 ## Not migrated (intentionally)
 

--- a/pkg/infra/db/mongodb/commitment_mongodb.go
+++ b/pkg/infra/db/mongodb/commitment_mongodb.go
@@ -58,6 +58,7 @@ func (r *CommitmentRepository) ensureIndexes(ctx context.Context) {
 	if err != nil {
 		slog.Error("Failed to create commitment indexes", "error", err)
 	}
+	EnsureResourceOwnershipIndexes(ctx, r.collection, false)
 }
 
 // Save persists a commitment (upsert)

--- a/pkg/infra/db/mongodb/game_connection_info_mongodb.go
+++ b/pkg/infra/db/mongodb/game_connection_info_mongodb.go
@@ -43,6 +43,7 @@ func (r *GameConnectionInfoRepository) ensureIndexes(ctx context.Context) {
 	if err != nil {
 		slog.Error("Failed to create game_connection_info indexes", "error", err)
 	}
+	EnsureResourceOwnershipIndexes(ctx, r.collection, false)
 }
 
 // Save persists game connection info (upsert)

--- a/pkg/infra/db/mongodb/lobby_mongodb.go
+++ b/pkg/infra/db/mongodb/lobby_mongodb.go
@@ -107,6 +107,9 @@ func (r *LobbyRepository) ensureIndexes() {
 	} else {
 		slog.Info("Lobby indexes ensured")
 	}
+
+	// Refs 2508-002 — nested resource_owner + flat dual-write keys
+	EnsureResourceOwnershipIndexes(ctx, r.collection, true)
 }
 
 // Create inserts a new lobby

--- a/pkg/infra/db/mongodb/match_result_mongodb.go
+++ b/pkg/infra/db/mongodb/match_result_mongodb.go
@@ -2,6 +2,7 @@ package mongodb
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/leet-gaming/match-making-api/pkg/domain/pairing/entities"
@@ -23,7 +24,11 @@ type matchResultRepository struct {
 
 // NewMatchResultRepository creates a MongoDB repository for match results.
 func NewMatchResultRepository(client *mongo.Client, dbName string) pairing_out.MatchResultRepository {
-	return &matchResultRepository{client: client, dbName: dbName}
+	repo := &matchResultRepository{client: client, dbName: dbName}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	EnsureResourceOwnershipIndexes(ctx, repo.collection(), true)
+	return repo
 }
 
 func (r *matchResultRepository) collection() *mongo.Collection {

--- a/pkg/infra/db/mongodb/player_rating_mongodb.go
+++ b/pkg/infra/db/mongodb/player_rating_mongodb.go
@@ -26,7 +26,11 @@ type playerRatingRepository struct {
 
 // NewPlayerRatingRepository creates a MongoDB repository for player ratings.
 func NewPlayerRatingRepository(client *mongo.Client, dbName string) pairing_out.PlayerRatingRepository {
-	return &playerRatingRepository{client: client, dbName: dbName}
+	repo := &playerRatingRepository{client: client, dbName: dbName}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	EnsureResourceOwnershipIndexes(ctx, repo.ratingsColl(), true)
+	return repo
 }
 
 func (r *playerRatingRepository) ratingsColl() *mongo.Collection {

--- a/pkg/infra/db/mongodb/push_token_mongodb.go
+++ b/pkg/infra/db/mongodb/push_token_mongodb.go
@@ -43,6 +43,7 @@ func (r *PushTokenRepository) ensureIndexes(ctx context.Context) {
 	if err != nil {
 		slog.Error("Failed to create push_token indexes", "error", err)
 	}
+	EnsureResourceOwnershipIndexes(ctx, r.collection, false)
 }
 
 // Save persists a push token (upsert)

--- a/pkg/infra/db/mongodb/resource_ownership_indexes.go
+++ b/pkg/infra/db/mongodb/resource_ownership_indexes.go
@@ -1,0 +1,73 @@
+package mongodb
+
+import (
+	"context"
+	"log/slog"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// ResourceOwnershipIndexModels returns compound indexes for nested resource_owner
+// (Refs 2508-002). Safe to CreateMany on collections that use common.BaseEntity
+// or dual-write nested ownership (lobby, player_ratings, match_results).
+func ResourceOwnershipIndexModels() []mongo.IndexModel {
+	return []mongo.IndexModel{
+		{
+			Keys: bson.D{
+				{Key: "resource_owner.tenant_id", Value: 1},
+				{Key: "resource_owner.client_id", Value: 1},
+			},
+			Options: options.Index().SetName("idx_ro_tenant_client"),
+		},
+		{
+			Keys: bson.D{
+				{Key: "resource_owner.tenant_id", Value: 1},
+				{Key: "resource_owner.user_id", Value: 1},
+			},
+			Options: options.Index().SetName("idx_ro_tenant_user"),
+		},
+		{
+			Keys: bson.D{
+				{Key: "resource_owner.tenant_id", Value: 1},
+				{Key: "resource_owner.group_id", Value: 1},
+			},
+			Options: options.Index().SetName("idx_ro_tenant_group"),
+		},
+	}
+}
+
+// FlatTenantClientIndexModels indexes legacy top-level tenant_id + client_id
+// during dual-write migration (2508-001 → 2508-002).
+func FlatTenantClientIndexModels() []mongo.IndexModel {
+	return []mongo.IndexModel{
+		{
+			Keys: bson.D{
+				{Key: "tenant_id", Value: 1},
+				{Key: "client_id", Value: 1},
+			},
+			Options: options.Index().SetName("idx_flat_tenant_client"),
+		},
+	}
+}
+
+// EnsureResourceOwnershipIndexes creates ownership indexes on collection.
+// Errors are logged and do not fail repository construction.
+func EnsureResourceOwnershipIndexes(ctx context.Context, collection *mongo.Collection, includeFlat bool) {
+	if collection == nil {
+		return
+	}
+	indexes := ResourceOwnershipIndexModels()
+	if includeFlat {
+		indexes = append(indexes, FlatTenantClientIndexModels()...)
+	}
+	_, err := collection.Indexes().CreateMany(ctx, indexes)
+	if err != nil {
+		slog.Warn("Failed to create resource ownership indexes",
+			"collection", collection.Name(),
+			"error", err)
+		return
+	}
+	slog.Info("Resource ownership indexes ensured", "collection", collection.Name())
+}

--- a/pkg/infra/db/mongodb/resource_ownership_indexes_test.go
+++ b/pkg/infra/db/mongodb/resource_ownership_indexes_test.go
@@ -1,0 +1,41 @@
+package mongodb
+
+import "testing"
+
+func TestResourceOwnershipIndexModels_Names(t *testing.T) {
+	t.Parallel()
+	models := ResourceOwnershipIndexModels()
+	if len(models) < 3 {
+		t.Fatalf("expected at least 3 ownership indexes, got %d", len(models))
+	}
+	want := map[string]bool{
+		"idx_ro_tenant_client": false,
+		"idx_ro_tenant_user":   false,
+		"idx_ro_tenant_group":  false,
+	}
+	for _, m := range models {
+		if m.Options == nil || m.Options.Name == nil {
+			t.Fatal("index missing name")
+		}
+		name := *m.Options.Name
+		if _, ok := want[name]; ok {
+			want[name] = true
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Fatalf("missing index name %s", name)
+		}
+	}
+}
+
+func TestFlatTenantClientIndexModels(t *testing.T) {
+	t.Parallel()
+	models := FlatTenantClientIndexModels()
+	if len(models) != 1 || models[0].Options == nil || models[0].Options.Name == nil {
+		t.Fatal("expected named flat tenant/client index")
+	}
+	if *models[0].Options.Name != "idx_flat_tenant_client" {
+		t.Fatalf("unexpected name %s", *models[0].Options.Name)
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds MongoDB compound indexes for nested `resource_owner` (tenant/client/user/group) on match-making collections, applied when repositories start. Flat `tenant_id`+`client_id` indexes remain for dual-write. Index strategy and explain() smoke guidance are documented.

**Depends on / stacks:** merge or include branch `37-2508-001-add-resource-ownership-to-entities` first (nested ownership fields).

Refs 2508-002.

## Key Features Added

### Resource Ownership Indexes

- **Shared helpers**: `ResourceOwnershipIndexModels`, `FlatTenantClientIndexModels`, `EnsureResourceOwnershipIndexes` in `pkg/infra/db/mongodb/resource_ownership_indexes.go`
- **Applied on repo init**: lobbies, player_ratings, match_results (nested + flat); commitments, push_tokens, game_connection_info (nested / BaseEntity)

### Documentation

- **Index strategy**: `.docs/RESOURCE_OWNERSHIP_INDEXES.md` — index names, collections, validation pointers, explain smoke for &lt;50ms target

### Validation

- Write-path ownership validation remains from Refs 2508-001 (`ValidateOwnership` on Lobby / PlayerRating / MatchResult)

## Architecture Highlights

**Design Patterns:**

- Centralized index definitions reused across repositories (CreateMany at startup; log-and-continue on failure)
- Dual-write period: nested `idx_ro_*` + flat `idx_flat_tenant_client`

**Key Components:**

- `resource_ownership_indexes.go` — models + Ensure helper
- Repository `New*` / `ensureIndexes` call sites for six collections

**Security & Best Practices:**

- Indexes support tenant-scoped queries without scanning
- No secrets in index keys

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [x] Test addition or update

## Related Issue

Refs 2508-002

## Test Plan

- [x] Build / unit: `go test -vet=off ./pkg/infra/db/mongodb/ -run "TestResourceOwnership|TestFlatTenant"` — PASS
- [ ] Run integration tests (if applicable)
- [ ] Manual testing performed
- [ ] All API endpoints tested
- [ ] Error handling verified
- [ ] Edge cases tested
- [ ] Performance tested (if applicable) — staging explain() documented in `.docs/RESOURCE_OWNERSHIP_INDEXES.md`
- [ ] Security checks performed
- [x] No sensitive data in commits

### Test Steps

1. Unit test index model names (command above)
2. Deploy / start API against Mongo — confirm `db.<coll>.getIndexes()` includes `idx_ro_tenant_client`
3. (Staging) Run explain smoke from `.docs/RESOURCE_OWNERSHIP_INDEXES.md`

## Files Changed

- Relative to `develop` (includes stacked 2508-001): 18 files, +603 / −45
- This commit alone: 10 files, +175 / −3

## Database Migration

No data migration. Indexes created automatically on repository construction (`CreateMany`). Optional: verify with `getIndexes()` after first boot.

## Dependencies

- [x] No new dependencies added
- [ ] New dependencies added (list below)
- [ ] Dependencies updated (list below)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published (merge 2508-001 first or open stacked PR)
- [x] All method names, comments, and documentation are in English (as per `.cursorrules`)
- [ ] OpenAPI specification updated (if API changes were made)
- [ ] Logging added for audit purposes (if applicable)

## Additional Notes

- Story remains **partial** until staging explain() &lt; 50ms is recorded and replay-api indexes (if any) are handled separately.
- Suggested PR title: `feat(ownership): add resource_owner Mongo indexes (2508-002)`
- Base: `develop` (or `37-2508-001-...` if stacking PRs)
- Branch: `38-2508-002-resource-ownership-indexes-and-validation`
